### PR TITLE
Consider using purl URLs?

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Version: 0.1.1
 Authors@R: person("Carl", "Boettiger", 
                   role=c("aut", "cre", "cph"), 
                   email="cboettig@gmail.com", 
-                  comment=c(ORCID = "http://orcid.org/0000-0002-1642-628X"))
+                  comment=c(ORCID = "0000-0002-1642-628X"))
 Description: The 'Codemeta' Project defines a 'JSON-LD' format for describing
   software metadata, as detailed at <https://codemeta.github.io>. This package
   provides utilities to generate, parse, and modify 'codemeta.jsonld' files 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,8 +12,8 @@ Description: The 'Codemeta' Project defines a 'JSON-LD' format for describing
   automatically for R packages, as well as tools and examples for working with
   'codemeta' 'JSON-LD' more generally.
 License: MIT + file LICENSE
-URL: https://github.com/codemeta/codemetar
-BugReports: https://github.com/codemeta/codemetar/issues
+URL: https://github.com/ropensci/codemetar
+BugReports: https://github.com/ropensci/codemetar/issues
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 6.0.1

--- a/R/codemeta_description.R
+++ b/R/codemeta_description.R
@@ -8,7 +8,8 @@
 
 ## Supporting old versions will be a nuciance
 new_codemeta <- function() {
-  list(`@context` = "https://doi.org/doi:10.5063/schema/codemeta-2.0",
+  list(`@context` = "http://purl.org/codemeta/2.0",
+         #"https://doi.org/doi:10.5063/schema/codemeta-2.0",
   `@type` = "SoftwareSourceCode")
 }
 

--- a/R/codemeta_description.R
+++ b/R/codemeta_description.R
@@ -5,12 +5,11 @@
 #options(codemeta_context =
 #  "https://raw.githubusercontent.com/codemeta/codemeta/master/codemeta.jsonld")
 
-
+options(codemeta_context = "http://purl.org/codemeta/2.0")
 ## Supporting old versions will be a nuciance
 new_codemeta <- function() {
-  list(`@context` = "http://purl.org/codemeta/2.0",
-         #"https://doi.org/doi:10.5063/schema/codemeta-2.0",
-  `@type` = "SoftwareSourceCode")
+  list(`@context` = getOption("codemeta_context","http://purl.org/codemeta/2.0"),
+       `@type` = "SoftwareSourceCode")
 }
 
 

--- a/R/codemetar.R
+++ b/R/codemetar.R
@@ -30,3 +30,5 @@
 #'
 "_PACKAGE"
 
+## JSON-LD needs content negotiation
+options("jsonld_use_accept" = TRUE)

--- a/R/crosswalk.R
+++ b/R/crosswalk.R
@@ -110,7 +110,7 @@ crosswalk_transform <- function(x,
   y <- jsonld::jsonld_expand(y)
 
   ## Sometimes fails to do remote lookup automatically from DOI, so download
-  if(!file.exists(codemeta_context)) {
+  if(is.character(codemeta_context) & grepl("https://doi", codemeta_context)) {
     f <- tempfile("codemeta", fileext="json")
     download.file(codemeta_context, f)
   } else {

--- a/R/crosswalk.R
+++ b/R/crosswalk.R
@@ -24,9 +24,9 @@
 crosswalk <- function(x,
                       from,
                       to = "codemeta",
-                      codemeta_context =
-                        "https://doi.org/10.5063/schema/codemeta-2.0"
-){
+                      codemeta_context = getOption("codemeta_context",
+                                                   "http://purl.org/codemeta/2.0")
+                      ){
 
   from_context <- get_crosswalk_context(crosswalk_table(from), codemeta_context)
   if(to != "codemeta"){
@@ -75,7 +75,8 @@ crosswalk_table <- function(from,
 get_crosswalk_context <-
   function(df,
            codemeta_context =
-             "https://doi.org/10.5063/schema/codemeta-2.0"){
+             getOption("codemeta_context",
+                       "http://purl.org/codemeta/2.0")){
 
     context <- jsonlite::read_json(codemeta_context)
     context[[1]][["id"]] <- NULL ## avoid collisions with @id
@@ -103,20 +104,13 @@ get_crosswalk_context <-
 crosswalk_transform <- function(x,
                                 crosswalk_context = NULL,
                                 codemeta_context =
-                                "https://doi.org/10.5063/schema/codemeta-2.0"){
+                                getOption("codemeta_context",
+                                          "http://purl.org/codemeta/2.0")){
 
   x <- add_context(x, crosswalk_context)
   y <- jsonlite::toJSON(x, auto_unbox = TRUE, pretty = TRUE)
   y <- jsonld::jsonld_expand(y)
-
-  ## Sometimes fails to do remote lookup automatically from DOI, so download
-  if(is.character(codemeta_context) & grepl("https://doi", codemeta_context)) {
-    f <- tempfile("codemeta", fileext="json")
-    download.file(codemeta_context, f)
-  } else {
-    f <- codemeta_context
-  }
-  y <- jsonld::jsonld_compact(y, context = f)
+  y <- jsonld::jsonld_compact(y, context = codemeta_context)
   y
 }
 

--- a/R/parse_people.R
+++ b/R/parse_people.R
@@ -60,6 +60,10 @@ person_to_schema <- function(p) {
   if (!is.null(p$comment)) {
     if (grepl("orcid", p$comment)) {
       id <- p$comment
+    } else if("ORCID" %in% names(p$comment)){
+      id <- p$comment[["ORCID"]]
+      if(!grepl("^http", id))
+        id <- paste0("http://orcid.org/", id)
     }
   }
 

--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ Which creates a file looking like so (first 10 lines; see full [codemeta.json he
 
     {
       "@context": [
-        "https://doi.org/doi:10.5063/schema/codemeta-2.0",
+        "http://purl.org/codemeta/2.0",
         "http://schema.org"
       ],
       "@type": "SoftwareSourceCode",
       "identifier": "codemetar",
       "description": "The 'Codemeta' Project defines a 'JSON-LD' format for describing\n  software metadata, as detailed at <https://codemeta.github.io>. This package\n  provides utilities to generate, parse, and modify 'codemeta.jsonld' files \n  automatically for R packages, as well as tools and examples for working with\n  'codemeta' 'JSON-LD' more generally.",
       "name": "codemetar: Generate CodeMeta Metadata for R Packages",
-      "issueTracker": "https://github.com/codemeta/codemetar/issues",
+      "issueTracker": "https://github.com/ropensci/codemetar/issues",
 
 Modifying or enriching CodeMeta metadata
 ----------------------------------------

--- a/codemeta.json
+++ b/codemeta.json
@@ -276,5 +276,5 @@
   "developmentStatus": "active",
   "releaseNotes": "https://github.com/ropensci/codemetar/blob/master/NEWS.md",
   "readme": "https://github.com/ropensci/codemetar/blob/master/README.md",
-  "fileSize": "657.616KB"
+  "fileSize": "662.417KB"
 }

--- a/codemeta.json
+++ b/codemeta.json
@@ -7,7 +7,7 @@
   "identifier": "codemetar",
   "description": "The 'Codemeta' Project defines a 'JSON-LD' format for describing\n  software metadata, as detailed at <https://codemeta.github.io>. This package\n  provides utilities to generate, parse, and modify 'codemeta.jsonld' files \n  automatically for R packages, as well as tools and examples for working with\n  'codemeta' 'JSON-LD' more generally.",
   "name": "codemetar: Generate CodeMeta Metadata for R Packages",
-  "issueTracker": "https://github.com/codemeta/codemetar/issues",
+  "issueTracker": "https://github.com/ropensci/codemetar/issues",
   "license": "https://spdx.org/licenses/MIT",
   "version": "0.1.1",
   "programmingLanguage": {
@@ -276,5 +276,5 @@
   "developmentStatus": "active",
   "releaseNotes": "https://github.com/ropensci/codemetar/blob/master/NEWS.md",
   "readme": "https://github.com/ropensci/codemetar/blob/master/README.md",
-  "fileSize": "657.49KB"
+  "fileSize": "658.414KB"
 }

--- a/codemeta.json
+++ b/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://doi.org/doi:10.5063/schema/codemeta-2.0",
+    "http://purl.org/codemeta/2.0",
     "http://schema.org"
   ],
   "@type": "SoftwareSourceCode",
@@ -276,5 +276,5 @@
   "developmentStatus": "active",
   "releaseNotes": "https://github.com/ropensci/codemetar/blob/master/NEWS.md",
   "readme": "https://github.com/ropensci/codemetar/blob/master/README.md",
-  "fileSize": "658.414KB"
+  "fileSize": "657.616KB"
 }

--- a/docs/LICENSE.html
+++ b/docs/LICENSE.html
@@ -52,7 +52,7 @@
     <div id="navbar" class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
         <li>
-  <a href="/index.html">
+  <a href="index.html">
     <span class="fa fa-home fa-lg"></span>
      
   </a>
@@ -88,7 +88,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/codemeta/codemetar">
+  <a href="https://github.com/ropensci/codemetar">
     <span class="fa fa-github fa-lg"></span>
      
   </a>

--- a/docs/articles/A-codemeta-intro.html
+++ b/docs/articles/A-codemeta-intro.html
@@ -29,7 +29,7 @@
     <div id="navbar" class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
 <li>
-  <a href="..//index.html">
+  <a href="../index.html">
     <span class="fa fa-home fa-lg"></span>
      
   </a>
@@ -64,7 +64,7 @@
       </ul>
 <ul class="nav navbar-nav navbar-right">
 <li>
-  <a href="https://github.com/codemeta/codemetar">
+  <a href="https://github.com/ropensci/codemetar">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -84,7 +84,7 @@
       <h1>Codemeta intro</h1>
                         <h4 class="author">Carl Boettiger</h4>
             
-            <h4 class="date">2017-10-17</h4>
+            <h4 class="date">2017-11-08</h4>
           </div>
 
     
@@ -131,7 +131,7 @@ devtools<span class="op">::</span><span class="kw"><a href="http://www.rdocument
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="../reference/write_codemeta.html">write_codemeta</a></span>(<span class="st">"."</span>)</code></pre></div>
 <pre><code>{
   "@context": [
-    "https://doi.org/doi:10.5063/schema/codemeta-2.0",
+    "http://purl.org/codemeta/2.0",
     "http://schema.org"
   ],
   "@type": "SoftwareSourceCode",

--- a/docs/articles/B-translating.html
+++ b/docs/articles/B-translating.html
@@ -29,7 +29,7 @@
     <div id="navbar" class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
 <li>
-  <a href="..//index.html">
+  <a href="../index.html">
     <span class="fa fa-home fa-lg"></span>
      
   </a>
@@ -64,7 +64,7 @@
       </ul>
 <ul class="nav navbar-nav navbar-right">
 <li>
-  <a href="https://github.com/codemeta/codemetar">
+  <a href="https://github.com/ropensci/codemetar">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -84,7 +84,7 @@
       <h1>Translating between schema using JSON-LD</h1>
                         <h4 class="author">Carl Boettiger</h4>
             
-            <h4 class="date">2017-10-17</h4>
+            <h4 class="date">2017-11-08</h4>
           </div>
 
     
@@ -140,327 +140,13 @@
 <p>Here we crosswalk the JSON data returned as the repository information from the GitHub API:</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">repo_info &lt;-<span class="st"> </span>gh<span class="op">::</span><span class="kw"><a href="http://www.rdocumentation.org/packages/gh/topics/gh">gh</a></span>(<span class="st">"/repos/:owner/:repo"</span>, <span class="dt">owner =</span> <span class="st">"ropensci"</span>, <span class="dt">repo =</span> <span class="st">"EML"</span>)</code></pre></div>
 <p>Let’s just take a look at what the returned json data looks like:</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">repo_info</code></pre></div>
-<pre><code>$id
-[1] 10894022
-
-$name
-[1] "EML"
-
-$full_name
-[1] "ropensci/EML"
-
-$owner
-$owner$login
-[1] "ropensci"
-
-$owner$id
-[1] 1200269
-
-$owner$avatar_url
-[1] "https://avatars0.githubusercontent.com/u/1200269?v=3"
-
-$owner$gravatar_id
-[1] ""
-
-$owner$url
-[1] "https://api.github.com/users/ropensci"
-
-$owner$html_url
-[1] "https://github.com/ropensci"
-
-$owner$followers_url
-[1] "https://api.github.com/users/ropensci/followers"
-
-$owner$following_url
-[1] "https://api.github.com/users/ropensci/following{/other_user}"
-
-$owner$gists_url
-[1] "https://api.github.com/users/ropensci/gists{/gist_id}"
-
-$owner$starred_url
-[1] "https://api.github.com/users/ropensci/starred{/owner}{/repo}"
-
-$owner$subscriptions_url
-[1] "https://api.github.com/users/ropensci/subscriptions"
-
-$owner$organizations_url
-[1] "https://api.github.com/users/ropensci/orgs"
-
-$owner$repos_url
-[1] "https://api.github.com/users/ropensci/repos"
-
-$owner$events_url
-[1] "https://api.github.com/users/ropensci/events{/privacy}"
-
-$owner$received_events_url
-[1] "https://api.github.com/users/ropensci/received_events"
-
-$owner$type
-[1] "Organization"
-
-$owner$site_admin
-[1] FALSE
-
-
-$private
-[1] FALSE
-
-$html_url
-[1] "https://github.com/ropensci/EML"
-
-$description
-[1] " Ecological Metadata Language interface for R: synthesis and integration of heterogenous data"
-
-$fork
-[1] FALSE
-
-$url
-[1] "https://api.github.com/repos/ropensci/EML"
-
-$forks_url
-[1] "https://api.github.com/repos/ropensci/EML/forks"
-
-$keys_url
-[1] "https://api.github.com/repos/ropensci/EML/keys{/key_id}"
-
-$collaborators_url
-[1] "https://api.github.com/repos/ropensci/EML/collaborators{/collaborator}"
-
-$teams_url
-[1] "https://api.github.com/repos/ropensci/EML/teams"
-
-$hooks_url
-[1] "https://api.github.com/repos/ropensci/EML/hooks"
-
-$issue_events_url
-[1] "https://api.github.com/repos/ropensci/EML/issues/events{/number}"
-
-$events_url
-[1] "https://api.github.com/repos/ropensci/EML/events"
-
-$assignees_url
-[1] "https://api.github.com/repos/ropensci/EML/assignees{/user}"
-
-$branches_url
-[1] "https://api.github.com/repos/ropensci/EML/branches{/branch}"
-
-$tags_url
-[1] "https://api.github.com/repos/ropensci/EML/tags"
-
-$blobs_url
-[1] "https://api.github.com/repos/ropensci/EML/git/blobs{/sha}"
-
-$git_tags_url
-[1] "https://api.github.com/repos/ropensci/EML/git/tags{/sha}"
-
-$git_refs_url
-[1] "https://api.github.com/repos/ropensci/EML/git/refs{/sha}"
-
-$trees_url
-[1] "https://api.github.com/repos/ropensci/EML/git/trees{/sha}"
-
-$statuses_url
-[1] "https://api.github.com/repos/ropensci/EML/statuses/{sha}"
-
-$languages_url
-[1] "https://api.github.com/repos/ropensci/EML/languages"
-
-$stargazers_url
-[1] "https://api.github.com/repos/ropensci/EML/stargazers"
-
-$contributors_url
-[1] "https://api.github.com/repos/ropensci/EML/contributors"
-
-$subscribers_url
-[1] "https://api.github.com/repos/ropensci/EML/subscribers"
-
-$subscription_url
-[1] "https://api.github.com/repos/ropensci/EML/subscription"
-
-$commits_url
-[1] "https://api.github.com/repos/ropensci/EML/commits{/sha}"
-
-$git_commits_url
-[1] "https://api.github.com/repos/ropensci/EML/git/commits{/sha}"
-
-$comments_url
-[1] "https://api.github.com/repos/ropensci/EML/comments{/number}"
-
-$issue_comment_url
-[1] "https://api.github.com/repos/ropensci/EML/issues/comments{/number}"
-
-$contents_url
-[1] "https://api.github.com/repos/ropensci/EML/contents/{+path}"
-
-$compare_url
-[1] "https://api.github.com/repos/ropensci/EML/compare/{base}...{head}"
-
-$merges_url
-[1] "https://api.github.com/repos/ropensci/EML/merges"
-
-$archive_url
-[1] "https://api.github.com/repos/ropensci/EML/{archive_format}{/ref}"
-
-$downloads_url
-[1] "https://api.github.com/repos/ropensci/EML/downloads"
-
-$issues_url
-[1] "https://api.github.com/repos/ropensci/EML/issues{/number}"
-
-$pulls_url
-[1] "https://api.github.com/repos/ropensci/EML/pulls{/number}"
-
-$milestones_url
-[1] "https://api.github.com/repos/ropensci/EML/milestones{/number}"
-
-$notifications_url
-[1] "https://api.github.com/repos/ropensci/EML/notifications{?since,all,participating}"
-
-$labels_url
-[1] "https://api.github.com/repos/ropensci/EML/labels{/name}"
-
-$releases_url
-[1] "https://api.github.com/repos/ropensci/EML/releases{/id}"
-
-$deployments_url
-[1] "https://api.github.com/repos/ropensci/EML/deployments"
-
-$created_at
-[1] "2013-06-23T23:20:03Z"
-
-$updated_at
-[1] "2017-05-11T21:24:40Z"
-
-$pushed_at
-[1] "2017-07-05T18:52:34Z"
-
-$git_url
-[1] "git://github.com/ropensci/EML.git"
-
-$ssh_url
-[1] "git@github.com:ropensci/EML.git"
-
-$clone_url
-[1] "https://github.com/ropensci/EML.git"
-
-$svn_url
-[1] "https://github.com/ropensci/EML"
-
-$homepage
-[1] "https://ropensci.github.io/EML"
-
-$size
-[1] 5094
-
-$stargazers_count
-[1] 48
-
-$watchers_count
-[1] 48
-
-$language
-[1] "HTML"
-
-$has_issues
-[1] TRUE
-
-$has_projects
-[1] TRUE
-
-$has_downloads
-[1] TRUE
-
-$has_wiki
-[1] TRUE
-
-$has_pages
-[1] TRUE
-
-$forks_count
-[1] 17
-
-$mirror_url
-named list()
-
-$open_issues_count
-[1] 35
-
-$forks
-[1] 17
-
-$open_issues
-[1] 35
-
-$watchers
-[1] 48
-
-$default_branch
-[1] "master"
-
-$organization
-$organization$login
-[1] "ropensci"
-
-$organization$id
-[1] 1200269
-
-$organization$avatar_url
-[1] "https://avatars0.githubusercontent.com/u/1200269?v=3"
-
-$organization$gravatar_id
-[1] ""
-
-$organization$url
-[1] "https://api.github.com/users/ropensci"
-
-$organization$html_url
-[1] "https://github.com/ropensci"
-
-$organization$followers_url
-[1] "https://api.github.com/users/ropensci/followers"
-
-$organization$following_url
-[1] "https://api.github.com/users/ropensci/following{/other_user}"
-
-$organization$gists_url
-[1] "https://api.github.com/users/ropensci/gists{/gist_id}"
-
-$organization$starred_url
-[1] "https://api.github.com/users/ropensci/starred{/owner}{/repo}"
-
-$organization$subscriptions_url
-[1] "https://api.github.com/users/ropensci/subscriptions"
-
-$organization$organizations_url
-[1] "https://api.github.com/users/ropensci/orgs"
-
-$organization$repos_url
-[1] "https://api.github.com/users/ropensci/repos"
-
-$organization$events_url
-[1] "https://api.github.com/users/ropensci/events{/privacy}"
-
-$organization$received_events_url
-[1] "https://api.github.com/users/ropensci/received_events"
-
-$organization$type
-[1] "Organization"
-
-$organization$site_admin
-[1] FALSE
-
-
-$network_count
-[1] 17
-
-$subscribers_count
-[1] 18</code></pre>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">repo_info <span class="op">%&gt;%</span><span class="st"> </span><span class="kw"><a href="http://www.rdocumentation.org/packages/jsonlite/topics/fromJSON">toJSON</a></span>()</code></pre></div>
+<pre><code>{"id":[10894022],"name":["EML"],"full_name":["ropensci/EML"],"owner":{"login":["ropensci"],"id":[1200269],"avatar_url":["https://avatars0.githubusercontent.com/u/1200269?v=3"],"gravatar_id":[""],"url":["https://api.github.com/users/ropensci"],"html_url":["https://github.com/ropensci"],"followers_url":["https://api.github.com/users/ropensci/followers"],"following_url":["https://api.github.com/users/ropensci/following{/other_user}"],"gists_url":["https://api.github.com/users/ropensci/gists{/gist_id}"],"starred_url":["https://api.github.com/users/ropensci/starred{/owner}{/repo}"],"subscriptions_url":["https://api.github.com/users/ropensci/subscriptions"],"organizations_url":["https://api.github.com/users/ropensci/orgs"],"repos_url":["https://api.github.com/users/ropensci/repos"],"events_url":["https://api.github.com/users/ropensci/events{/privacy}"],"received_events_url":["https://api.github.com/users/ropensci/received_events"],"type":["Organization"],"site_admin":[false]},"private":[false],"html_url":["https://github.com/ropensci/EML"],"description":[" Ecological Metadata Language interface for R: synthesis and integration of heterogenous data"],"fork":[false],"url":["https://api.github.com/repos/ropensci/EML"],"forks_url":["https://api.github.com/repos/ropensci/EML/forks"],"keys_url":["https://api.github.com/repos/ropensci/EML/keys{/key_id}"],"collaborators_url":["https://api.github.com/repos/ropensci/EML/collaborators{/collaborator}"],"teams_url":["https://api.github.com/repos/ropensci/EML/teams"],"hooks_url":["https://api.github.com/repos/ropensci/EML/hooks"],"issue_events_url":["https://api.github.com/repos/ropensci/EML/issues/events{/number}"],"events_url":["https://api.github.com/repos/ropensci/EML/events"],"assignees_url":["https://api.github.com/repos/ropensci/EML/assignees{/user}"],"branches_url":["https://api.github.com/repos/ropensci/EML/branches{/branch}"],"tags_url":["https://api.github.com/repos/ropensci/EML/tags"],"blobs_url":["https://api.github.com/repos/ropensci/EML/git/blobs{/sha}"],"git_tags_url":["https://api.github.com/repos/ropensci/EML/git/tags{/sha}"],"git_refs_url":["https://api.github.com/repos/ropensci/EML/git/refs{/sha}"],"trees_url":["https://api.github.com/repos/ropensci/EML/git/trees{/sha}"],"statuses_url":["https://api.github.com/repos/ropensci/EML/statuses/{sha}"],"languages_url":["https://api.github.com/repos/ropensci/EML/languages"],"stargazers_url":["https://api.github.com/repos/ropensci/EML/stargazers"],"contributors_url":["https://api.github.com/repos/ropensci/EML/contributors"],"subscribers_url":["https://api.github.com/repos/ropensci/EML/subscribers"],"subscription_url":["https://api.github.com/repos/ropensci/EML/subscription"],"commits_url":["https://api.github.com/repos/ropensci/EML/commits{/sha}"],"git_commits_url":["https://api.github.com/repos/ropensci/EML/git/commits{/sha}"],"comments_url":["https://api.github.com/repos/ropensci/EML/comments{/number}"],"issue_comment_url":["https://api.github.com/repos/ropensci/EML/issues/comments{/number}"],"contents_url":["https://api.github.com/repos/ropensci/EML/contents/{+path}"],"compare_url":["https://api.github.com/repos/ropensci/EML/compare/{base}...{head}"],"merges_url":["https://api.github.com/repos/ropensci/EML/merges"],"archive_url":["https://api.github.com/repos/ropensci/EML/{archive_format}{/ref}"],"downloads_url":["https://api.github.com/repos/ropensci/EML/downloads"],"issues_url":["https://api.github.com/repos/ropensci/EML/issues{/number}"],"pulls_url":["https://api.github.com/repos/ropensci/EML/pulls{/number}"],"milestones_url":["https://api.github.com/repos/ropensci/EML/milestones{/number}"],"notifications_url":["https://api.github.com/repos/ropensci/EML/notifications{?since,all,participating}"],"labels_url":["https://api.github.com/repos/ropensci/EML/labels{/name}"],"releases_url":["https://api.github.com/repos/ropensci/EML/releases{/id}"],"deployments_url":["https://api.github.com/repos/ropensci/EML/deployments"],"created_at":["2013-06-23T23:20:03Z"],"updated_at":["2017-05-11T21:24:40Z"],"pushed_at":["2017-07-05T18:52:34Z"],"git_url":["git://github.com/ropensci/EML.git"],"ssh_url":["git@github.com:ropensci/EML.git"],"clone_url":["https://github.com/ropensci/EML.git"],"svn_url":["https://github.com/ropensci/EML"],"homepage":["https://ropensci.github.io/EML"],"size":[5094],"stargazers_count":[48],"watchers_count":[48],"language":["HTML"],"has_issues":[true],"has_projects":[true],"has_downloads":[true],"has_wiki":[true],"has_pages":[true],"forks_count":[17],"mirror_url":{},"open_issues_count":[35],"forks":[17],"open_issues":[35],"watchers":[48],"default_branch":["master"],"organization":{"login":["ropensci"],"id":[1200269],"avatar_url":["https://avatars0.githubusercontent.com/u/1200269?v=3"],"gravatar_id":[""],"url":["https://api.github.com/users/ropensci"],"html_url":["https://github.com/ropensci"],"followers_url":["https://api.github.com/users/ropensci/followers"],"following_url":["https://api.github.com/users/ropensci/following{/other_user}"],"gists_url":["https://api.github.com/users/ropensci/gists{/gist_id}"],"starred_url":["https://api.github.com/users/ropensci/starred{/owner}{/repo}"],"subscriptions_url":["https://api.github.com/users/ropensci/subscriptions"],"organizations_url":["https://api.github.com/users/ropensci/orgs"],"repos_url":["https://api.github.com/users/ropensci/repos"],"events_url":["https://api.github.com/users/ropensci/events{/privacy}"],"received_events_url":["https://api.github.com/users/ropensci/received_events"],"type":["Organization"],"site_admin":[false]},"network_count":[17],"subscribers_count":[18]} </code></pre>
 <p>We can crosswalk this information into codemeta just by supplying the column name to the <code>crosswalk</code> function. This performs the same expansion of the metadata in the GitHub context, followed by compaction into the codemeta context. Note that terms not recognized/included in the codemeta context will be dropped:</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">github_meta &lt;-<span class="st"> </span><span class="kw"><a href="../reference/crosswalk.html">crosswalk</a></span>(repo_info, <span class="st">"GitHub"</span>)
 github_meta</code></pre></div>
 <pre><code>{
-  "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
+  "@context": "http://purl.org/codemeta/2.0",
   "codeRepository": "https://github.com/ropensci/EML",
   "dateCreated": "2013-06-23T23:20:03Z",
   "dateModified": "2017-05-11T21:24:40Z",
@@ -570,7 +256,7 @@ $license
 [1] "MIT"</code></pre>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="../reference/crosswalk.html">crosswalk</a></span>(package.json, <span class="st">"NodeJS"</span>)</code></pre></div>
 <pre><code>{
-  "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
+  "@context": "http://purl.org/codemeta/2.0",
   "codeRepository": {},
   "creator": "Mark Pundsack",
   "description": "A sample Node.js app using Express 4",

--- a/docs/articles/C-validation-in-json-ld.html
+++ b/docs/articles/C-validation-in-json-ld.html
@@ -29,7 +29,7 @@
     <div id="navbar" class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
 <li>
-  <a href="..//index.html">
+  <a href="../index.html">
     <span class="fa fa-home fa-lg"></span>
      
   </a>
@@ -64,7 +64,7 @@
       </ul>
 <ul class="nav navbar-nav navbar-right">
 <li>
-  <a href="https://github.com/codemeta/codemetar">
+  <a href="https://github.com/ropensci/codemetar">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -84,7 +84,7 @@
       <h1>Validation in JSON-LD</h1>
                         <h4 class="author">Carl Boettiger</h4>
             
-            <h4 class="date">2017-10-17</h4>
+            <h4 class="date">2017-11-08</h4>
           </div>
 
     
@@ -108,7 +108,7 @@
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">codemeta &lt;-<span class="st"> </span>
 <span class="st">'</span>
 <span class="st">{</span>
-<span class="st">  "@context": "https://doi.org/doi:10.5063/schema/codemeta-2.0",</span>
+<span class="st">  "@context": "http://purl.org/codemeta/2.0",</span>
 <span class="st">  "@type": "SoftwareSourceCode",</span>
 <span class="st">  "name": "codemetar: Generate CodeMeta Metadata for R Packages",</span>
 <span class="st">  "datePublished":" 2017-05-20",</span>
@@ -124,13 +124,35 @@
 <span class="st">  "maintainer":  {"@id": "http://orcid.org/0000-0002-1642-628X"}</span>
 <span class="st">}</span>
 <span class="st">'</span></code></pre></div>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">jsonld<span class="op">::</span><span class="kw"><a href="http://www.rdocumentation.org/packages/jsonld/topics/jsonld">jsonld_compact</a></span>(codemeta, <span class="st">"http://purl.org/codemeta/2.0"</span>)</code></pre></div>
+<pre><code>{
+  "@context": "http://purl.org/codemeta/2.0",
+  "type": "SoftwareSourceCode",
+  "author": [
+    {
+      "id": "http://orcid.org/0000-0002-1642-628X",
+      "type": "Person",
+      "email": "cboettig@gmail.com",
+      "familyName": "Boettiger",
+      "givenName": "Carl"
+    }
+  ],
+  "datePublished": " 2017-05-20",
+  "name": "codemetar: Generate CodeMeta Metadata for R Packages",
+  "version": 1,
+  "maintainer": {
+    "id": "http://orcid.org/0000-0002-1642-628X"
+  }
+} </code></pre>
 </div>
 <div id="framing-subsetting-data" class="section level2">
 <h2 class="hasAnchor">
 <a href="#framing-subsetting-data" class="anchor"></a>Framing: subsetting data</h2>
 <p>By default, frames return all the input data, while our application may only be interested in some subset. Often it is sufficient just to ignore these additional terms: in the example above it’s just as easy for our application to work with author elements whether or not we have dropped other elements such as <code>meta$version</code>. To restrict a frame to returning only the nodes we explicitly mention, we can use the keyword <code>@explicit</code>:</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">frame &lt;-<span class="st"> '{</span>
-<span class="st">  "@context": "https://doi.org/doi:10.5063/schema/codemeta-2.0",</span>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">options</span>(<span class="dt">jsonld_use_accept =</span> <span class="ot">TRUE</span>)
+
+frame &lt;-<span class="st"> '{</span>
+<span class="st">  "@context": "http://purl.org/codemeta/2.0",</span>
 <span class="st">  "@explicit": "true",</span>
 <span class="st">  "@type": "Person",</span>
 <span class="st">  "givenName": {},</span>
@@ -169,9 +191,10 @@ $givenName
 [1] "http://orcid.org/0000-0002-1642-628X"</code></pre>
 <p>We can use a frame with the special directive <code>"@embed": "@always"</code> to say that we want the full maintainer information embedded an not just referred to by id alone. Then we can subset <code>maintainer</code> just like we do author.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">frame &lt;-<span class="st"> '{</span>
-<span class="st">  "@context": "https://doi.org/doi:10.5063/schema/codemeta-2.0",</span>
+<span class="st">  "@context": "http://purl.org/codemeta/2.0",</span>
 <span class="st">  "@embed": "@always"</span>
 <span class="st">}'</span>
+
 
 meta &lt;-<span class="st"> </span>
 <span class="st">  </span><span class="kw"><a href="http://www.rdocumentation.org/packages/jsonld/topics/jsonld">jsonld_frame</a></span>(codemeta, frame) <span class="op">%&gt;%</span>
@@ -189,7 +212,7 @@ meta &lt;-<span class="st"> </span>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">codemeta &lt;-<span class="st"> </span>
 <span class="st">'</span>
 <span class="st">{</span>
-<span class="st">  "@context": "https://doi.org/doi:10.5063/schema/codemeta-2.0",</span>
+<span class="st">  "@context": "https://purl.org/codemeta/2.0",</span>
 <span class="st">  "@type": "SoftwareSourceCode",</span>
 <span class="st">  "name": "codemetar: Generate CodeMeta Metadata for R Packages",</span>
 <span class="st">  "buildInstructions": { </span>
@@ -200,12 +223,12 @@ meta &lt;-<span class="st"> </span>
 <span class="st">'</span></code></pre></div>
 <p>When we perform a framing or compaction operation, <code>buildInstructions</code> gets de-referenced to <code>codemeta:buildInstructions</code>, because it does not match the context. This means that if our application asks for <code>meta$buildInstructions</code>:</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">meta &lt;-
-<span class="st">  </span><span class="kw"><a href="http://www.rdocumentation.org/packages/jsonld/topics/jsonld">jsonld_frame</a></span>(codemeta, <span class="st">'{"@context": "https://doi.org/doi:10.5063/schema/codemeta-2.0"}'</span>) <span class="op">%&gt;%</span><span class="st"> </span>
+<span class="st">  </span><span class="kw"><a href="http://www.rdocumentation.org/packages/jsonld/topics/jsonld">jsonld_frame</a></span>(codemeta, <span class="st">'{"@context": "https://purl.org/codemeta/2.0"}'</span>) <span class="op">%&gt;%</span><span class="st"> </span>
 <span class="st">  </span><span class="kw"><a href="http://www.rdocumentation.org/packages/jsonlite/topics/fromJSON">fromJSON</a></span>(codemeta, <span class="dt">simplifyVector =</span> <span class="ot">FALSE</span>) <span class="op">%&gt;%</span><span class="st">  </span>
 <span class="st">  </span><span class="kw">getElement</span>(<span class="st">"@graph"</span>) <span class="op">%&gt;%</span><span class="st"> </span><span class="kw">getElement</span>(<span class="dv">1</span>)    
 
 ## above is same as compacting:
-<span class="co">#jsonld_compact(codemeta, "https://doi.org/doi:10.5063/schema/codemeta-2.0") %&gt;% </span>
+<span class="co">#jsonld_compact(codemeta, "http://purl.org/codemeta/2.0") %&gt;% </span>
 <span class="co">#  fromJSON(codemeta, simplifyVector = FALSE)</span>
 
 meta<span class="op">$</span>buildInstructions</code></pre></div>

--- a/docs/articles/D-codemeta-parsing.html
+++ b/docs/articles/D-codemeta-parsing.html
@@ -29,7 +29,7 @@
     <div id="navbar" class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
 <li>
-  <a href="..//index.html">
+  <a href="../index.html">
     <span class="fa fa-home fa-lg"></span>
      
   </a>
@@ -64,7 +64,7 @@
       </ul>
 <ul class="nav navbar-nav navbar-right">
 <li>
-  <a href="https://github.com/codemeta/codemetar">
+  <a href="https://github.com/ropensci/codemetar">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -84,7 +84,7 @@
       <h1>Parsing Codmeta Data</h1>
                         <h4 class="author">Carl Boettiger</h4>
             
-            <h4 class="date">2017-10-17</h4>
+            <h4 class="date">2017-11-08</h4>
           </div>
 
     
@@ -135,11 +135,11 @@ be recycled: author</code></pre>
 <pre><code>@Manual{codemetar,
   title = {codemetar: Generate CodeMeta Metadata for R Packages},
   year = {2017},
-  note = {R package version 0.1.0},
+  note = {R package version 0.1.1},
 }</code></pre>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">bibitem</code></pre></div>
 <pre><code>(2017). _codemetar: Generate CodeMeta Metadata for R Packages_. R
-package version 0.1.0.</code></pre>
+package version 0.1.1.</code></pre>
 <div id="parsing-the-ropensci-corpus" class="section level2">
 <h2 class="hasAnchor">
 <a href="#parsing-the-ropensci-corpus" class="anchor"></a>Parsing the ropensci corpus</h2>

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -52,7 +52,7 @@
     <div id="navbar" class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
         <li>
-  <a href="..//index.html">
+  <a href="../index.html">
     <span class="fa fa-home fa-lg"></span>
      
   </a>
@@ -88,7 +88,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/codemeta/codemetar">
+  <a href="https://github.com/ropensci/codemetar">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -102,7 +102,7 @@
       </header>
 
       <div class="page-header">
-  <h1>Articles <small>version&nbsp;0.1.0</small></h1>
+  <h1>Articles <small>version&nbsp;0.1.1</small></h1>
 </div>
 
 <div class="row">

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -52,7 +52,7 @@
     <div id="navbar" class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
         <li>
-  <a href="/index.html">
+  <a href="index.html">
     <span class="fa fa-home fa-lg"></span>
      
   </a>
@@ -88,7 +88,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/codemeta/codemetar">
+  <a href="https://github.com/ropensci/codemetar">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -109,7 +109,7 @@
 
     <ul class="list-unstyled">
       <li>
-        <p><strong>Carl Boettiger</strong>. Author, maintainer, copyright&nbsp;holder.
+        <p><strong>Carl Boettiger</strong>. Author, maintainer, copyright holder.
         <br /><small>http://orcid.org/0000-0002-1642-628X</small></p>
       </li>
     </ul>

--- a/docs/codemeta.json
+++ b/docs/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://doi.org/doi:10.5063/schema/codemeta-2.0",
+    "http://purl.org/codemeta/2.0",
     "http://schema.org"
   ],
   "@type": "SoftwareSourceCode",

--- a/docs/index.html
+++ b/docs/index.html
@@ -29,7 +29,7 @@
     <div id="navbar" class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
 <li>
-  <a href="/index.html">
+  <a href="index.html">
     <span class="fa fa-home fa-lg"></span>
      
   </a>
@@ -64,7 +64,7 @@
       </ul>
 <ul class="nav navbar-nav navbar-right">
 <li>
-  <a href="https://github.com/codemeta/codemetar">
+  <a href="https://github.com/ropensci/codemetar">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -109,7 +109,7 @@ devtools<span class="op">::</span><span class="kw"><a href="http://www.rdocument
 <p>Which creates a file looking like so (first 10 lines; see full <a href="https://github.com/codemeta/codemetar/blob/master/codemeta.json">codemeta.json here</a>):</p>
 <pre><code>{
   "@context": [
-    "https://doi.org/doi:10.5063/schema/codemeta-2.0",
+    "http://purl.org/codemeta/2.0",
     "http://schema.org"
   ],
   "@type": "SoftwareSourceCode",
@@ -149,24 +149,24 @@ devtools<span class="op">::</span><span class="kw"><a href="http://www.rdocument
     <h2 class="hasAnchor">
 <a href="#sidebar" class="anchor"></a>Links</h2>
 <ul class="list-unstyled">
-<li>Browse source code at <br><a href="https://github.com/codemeta/codemetar">https://​github.com/​codemeta/​codemetar</a>
+<li>Browse source code at <br><a href="https://github.com/ropensci/codemetar">https://​github.com/​ropensci/​codemetar</a>
 </li>
-<li>Report a bug at <br><a href="https://github.com/codemeta/codemetar/issues">https://​github.com/​codemeta/​codemetar/​issues</a>
+<li>Report a bug at <br><a href="https://github.com/ropensci/codemetar/issues">https://​github.com/​ropensci/​codemetar/​issues</a>
 </li>
 </ul>
 <h2>License</h2>
 <p><a href="https://opensource.org/licenses/mit-license.php">MIT</a> + file <a href="LICENSE.html">LICENSE</a></p>
 <h2>Developers</h2>
 <ul class="list-unstyled">
-<li>Carl Boettiger <br><small class="roles"> Author, maintainer, copyright holder </small> <br><small>(http://orcid.org/0000-0002-1642-628X)</small>
+<li>Carl Boettiger <br><small class="roles"> Author, maintainer, copyright holder </small> <br><small>(http://orcid.org/0000-0002-1642-628X)</small>
 </li>
 </ul>
 <h2>Dev status</h2>
 <ul class="list-unstyled">
 <li><a href="http://www.repostatus.org/#active"><img src="http://www.repostatus.org/badges/latest/active.svg" alt="Project Status: Active – The project has reached a stable, usable state and is being actively developed."></a></li>
-<li><a href="https://travis-ci.org/codemeta/codemetar"><img src="https://travis-ci.org/codemeta/codemetar.svg?branch=master" alt="Travis-CI Build Status"></a></li>
-<li><a href="https://ci.appveyor.com/project/cboettig/codemetar"><img src="https://ci.appveyor.com/api/projects/status/github/codemeta/codemetar?branch=master&amp;svg=true" alt="AppVeyor Build Status"></a></li>
-<li><a href="https://codecov.io/github/codemeta/codemetar?branch=master"><img src="https://img.shields.io/codecov/c/github/codemeta/codemetar/master.svg" alt="Coverage Status"></a></li>
+<li><a href="https://travis-ci.org/ropensci/codemetar"><img src="https://travis-ci.org/ropensci/codemetar.svg?branch=master" alt="Travis-CI Build Status"></a></li>
+<li><a href="https://ci.appveyor.com/project/cboettig/codemetar"><img src="https://ci.appveyor.com/api/projects/status/github/cboettig/codemetar?branch=master&amp;svg=true" alt="AppVeyor Build Status"></a></li>
+<li><a href="https://codecov.io/github/ropensci/codemetar?branch=master"><img src="https://img.shields.io/codecov/c/github/ropensci/codemetar/master.svg" alt="Coverage Status"></a></li>
 <li><a href="https://cran.r-project.org/package=codemetar"><img src="http://www.r-pkg.org/badges/version/codemetar" alt="CRAN_Status_Badge"></a></li>
 <li><a href="https://github.com/ropensci/onboarding/issues/130"><img src="http://badges.ropensci.org/130_status.svg"></a></li>
 </ul>

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -52,7 +52,7 @@
     <div id="navbar" class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
         <li>
-  <a href="..//index.html">
+  <a href="../index.html">
     <span class="fa fa-home fa-lg"></span>
      
   </a>
@@ -88,7 +88,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/codemeta/codemetar">
+  <a href="https://github.com/ropensci/codemetar">
     <span class="fa fa-github fa-lg"></span>
      
   </a>

--- a/docs/reference/add_context.html
+++ b/docs/reference/add_context.html
@@ -52,7 +52,7 @@
     <div id="navbar" class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
         <li>
-  <a href="..//index.html">
+  <a href="../index.html">
     <span class="fa fa-home fa-lg"></span>
      
   </a>
@@ -88,7 +88,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/codemeta/codemetar">
+  <a href="https://github.com/ropensci/codemetar">
     <span class="fa fa-github fa-lg"></span>
      
   </a>

--- a/docs/reference/codemeta.json
+++ b/docs/reference/codemeta.json
@@ -1,4 +1,4 @@
 {
-  "@context": ["https://doi.org/doi:10.5063/schema/codemeta-2.0", "http://schema.org"],
+  "@context": ["http://purl.org/codemeta/2.0", "http://schema.org"],
   "@type": "SoftwareSourceCode"
 }

--- a/docs/reference/codemeta_validate.html
+++ b/docs/reference/codemeta_validate.html
@@ -52,7 +52,7 @@
     <div id="navbar" class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
         <li>
-  <a href="..//index.html">
+  <a href="../index.html">
     <span class="fa fa-home fa-lg"></span>
      
   </a>
@@ -88,7 +88,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/codemeta/codemetar">
+  <a href="https://github.com/ropensci/codemetar">
     <span class="fa fa-github fa-lg"></span>
      
   </a>

--- a/docs/reference/codemetar-package.html
+++ b/docs/reference/codemetar-package.html
@@ -52,7 +52,7 @@
     <div id="navbar" class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
         <li>
-  <a href="..//index.html">
+  <a href="../index.html">
     <span class="fa fa-home fa-lg"></span>
      
   </a>
@@ -88,7 +88,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/codemeta/codemetar">
+  <a href="https://github.com/ropensci/codemetar">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -139,8 +139,8 @@ Developer Guide (https://codemeta.github.io/developer-guide/).</p>
     <h2 class="hasAnchor" id="see-also"><a class="anchor" href="#see-also"></a>See also</h2>
 
     <p>Useful links:</p><ul>
-<li><p><a href='https://github.com/codemeta/codemetar'>https://github.com/codemeta/codemetar</a></p></li>
-<li><p>Report bugs at <a href='https://github.com/codemeta/codemetar/issues'>https://github.com/codemeta/codemetar/issues</a></p></li>
+<li><p><a href='https://github.com/ropensci/codemetar'>https://github.com/ropensci/codemetar</a></p></li>
+<li><p>Report bugs at <a href='https://github.com/ropensci/codemetar/issues'>https://github.com/ropensci/codemetar/issues</a></p></li>
 </ul>
     
 

--- a/docs/reference/create_codemeta.html
+++ b/docs/reference/create_codemeta.html
@@ -52,7 +52,7 @@
     <div id="navbar" class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
         <li>
-  <a href="..//index.html">
+  <a href="../index.html">
     <span class="fa fa-home fa-lg"></span>
      
   </a>
@@ -88,7 +88,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/codemeta/codemetar">
+  <a href="https://github.com/ropensci/codemetar">
     <span class="fa fa-github fa-lg"></span>
      
   </a>

--- a/docs/reference/crosswalk.html
+++ b/docs/reference/crosswalk.html
@@ -52,7 +52,7 @@
     <div id="navbar" class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
         <li>
-  <a href="..//index.html">
+  <a href="../index.html">
     <span class="fa fa-home fa-lg"></span>
      
   </a>
@@ -88,7 +88,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/codemeta/codemetar">
+  <a href="https://github.com/ropensci/codemetar">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -116,7 +116,8 @@ to a given JSON metadata record.</p>
     
 
     <pre class="usage"><span class='fu'>crosswalk</span>(<span class='no'>x</span>, <span class='no'>from</span>, <span class='kw'>to</span> <span class='kw'>=</span> <span class='st'>"codemeta"</span>,
-  <span class='kw'>codemeta_context</span> <span class='kw'>=</span> <span class='st'>"https://doi.org/10.5063/schema/codemeta-2.0"</span>)</pre>
+  <span class='kw'>codemeta_context</span> <span class='kw'>=</span> <span class='fu'>getOption</span>(<span class='st'>"codemeta_context"</span>,
+  <span class='st'>"http://purl.org/codemeta/2.0"</span>))</pre>
     
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a> Arguments</h2>
     <table class="ref-arguments">

--- a/docs/reference/crosswalk_table.html
+++ b/docs/reference/crosswalk_table.html
@@ -52,7 +52,7 @@
     <div id="navbar" class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
         <li>
-  <a href="..//index.html">
+  <a href="../index.html">
     <span class="fa fa-home fa-lg"></span>
      
   </a>
@@ -88,7 +88,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/codemeta/codemetar">
+  <a href="https://github.com/ropensci/codemetar">
     <span class="fa fa-github fa-lg"></span>
      
   </a>

--- a/docs/reference/crosswalk_transform.html
+++ b/docs/reference/crosswalk_transform.html
@@ -52,7 +52,7 @@
     <div id="navbar" class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
         <li>
-  <a href="..//index.html">
+  <a href="../index.html">
     <span class="fa fa-home fa-lg"></span>
      
   </a>
@@ -88,7 +88,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/codemeta/codemetar">
+  <a href="https://github.com/ropensci/codemetar">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -112,7 +112,8 @@
     
 
     <pre class="usage"><span class='fu'>crosswalk_transform</span>(<span class='no'>x</span>, <span class='kw'>crosswalk_context</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
-  <span class='kw'>codemeta_context</span> <span class='kw'>=</span> <span class='st'>"https://doi.org/10.5063/schema/codemeta-2.0"</span>)</pre>
+  <span class='kw'>codemeta_context</span> <span class='kw'>=</span> <span class='fu'>getOption</span>(<span class='st'>"codemeta_context"</span>,
+  <span class='st'>"http://purl.org/codemeta/2.0"</span>))</pre>
     
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a> Arguments</h2>
     <table class="ref-arguments">

--- a/docs/reference/drop_context.html
+++ b/docs/reference/drop_context.html
@@ -52,7 +52,7 @@
     <div id="navbar" class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
         <li>
-  <a href="..//index.html">
+  <a href="../index.html">
     <span class="fa fa-home fa-lg"></span>
      
   </a>
@@ -88,7 +88,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/codemeta/codemetar">
+  <a href="https://github.com/ropensci/codemetar">
     <span class="fa fa-github fa-lg"></span>
      
   </a>

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -52,7 +52,7 @@
     <div id="navbar" class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
         <li>
-  <a href="..//index.html">
+  <a href="../index.html">
     <span class="fa fa-home fa-lg"></span>
      
   </a>
@@ -88,7 +88,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/codemeta/codemetar">
+  <a href="https://github.com/ropensci/codemetar">
     <span class="fa fa-github fa-lg"></span>
      
   </a>
@@ -106,7 +106,7 @@
     <div class="page-header">
       <h1>
         Reference
-        <small>version&nbsp;0.1.0</small>
+        <small>version&nbsp;0.1.1</small>
       </h1>
     </div>
 
@@ -140,7 +140,7 @@
         </tr><tr>
           <!--  -->
           <td>
-            <p></p>
+            <p><code><a href="codemetar-package.html">codemetar-package</a></code> </p>
           </td>
           <td><p>codemetar: generate codemeta metadata for R packages</p></td>
         </tr><tr>

--- a/docs/reference/write_codemeta.html
+++ b/docs/reference/write_codemeta.html
@@ -52,7 +52,7 @@
     <div id="navbar" class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
         <li>
-  <a href="..//index.html">
+  <a href="../index.html">
     <span class="fa fa-home fa-lg"></span>
      
   </a>
@@ -88,7 +88,7 @@
       
       <ul class="nav navbar-nav navbar-right">
         <li>
-  <a href="https://github.com/codemeta/codemetar">
+  <a href="https://github.com/ropensci/codemetar">
     <span class="fa fa-github fa-lg"></span>
      
   </a>

--- a/man/codemetar-package.Rd
+++ b/man/codemetar-package.Rd
@@ -38,8 +38,8 @@ Developer Guide (https://codemeta.github.io/developer-guide/).
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://github.com/codemeta/codemetar}
-  \item Report bugs at \url{https://github.com/codemeta/codemetar/issues}
+  \item \url{https://github.com/ropensci/codemetar}
+  \item Report bugs at \url{https://github.com/ropensci/codemetar/issues}
 }
 
 }

--- a/man/codemetar-package.Rd
+++ b/man/codemetar-package.Rd
@@ -44,6 +44,6 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Carl Boettiger \email{cboettig@gmail.com} (http://orcid.org/0000-0002-1642-628X) [copyright holder]
+\strong{Maintainer}: Carl Boettiger \email{cboettig@gmail.com} (0000-0002-1642-628X) [copyright holder]
 
 }

--- a/man/crosswalk.Rd
+++ b/man/crosswalk.Rd
@@ -5,7 +5,8 @@
 \title{crosswalk}
 \usage{
 crosswalk(x, from, to = "codemeta",
-  codemeta_context = "https://doi.org/10.5063/schema/codemeta-2.0")
+  codemeta_context = getOption("codemeta_context",
+  "http://purl.org/codemeta/2.0"))
 }
 \arguments{
 \item{x}{a JSON list or file with data fields to be crosswalked}

--- a/man/crosswalk_transform.Rd
+++ b/man/crosswalk_transform.Rd
@@ -5,7 +5,8 @@
 \title{Crosswalk transform}
 \usage{
 crosswalk_transform(x, crosswalk_context = NULL,
-  codemeta_context = "https://doi.org/10.5063/schema/codemeta-2.0")
+  codemeta_context = getOption("codemeta_context",
+  "http://purl.org/codemeta/2.0"))
 }
 \arguments{
 \item{x}{a JSON list or file with data fields to be crosswalked}

--- a/tests/testthat/test-crosswalk.R
+++ b/tests/testthat/test-crosswalk.R
@@ -22,7 +22,7 @@ testthat::test_that("we can call crosswalk", {
 
   ## Test add and drop context
   b <- drop_context(a)
-  add_context(b, "https://doi.org/doi:10.5063/schema/codemeta-2.0")
+  add_context(b, getOption("codemeta_context", "http://purl.org/codemeta/2.0"))
 
 
   ## Test transforms between columns

--- a/tests/testthat/test-jsonld-compact.R
+++ b/tests/testthat/test-jsonld-compact.R
@@ -1,0 +1,24 @@
+context("test minimal jsonld with content negotiation")
+
+#library(jsonld)
+#options(jsonld_use_accept = TRUE)
+#jsonld::jsonld_compact(
+#  "https://raw.githubusercontent.com/codemeta/codemetar/master/codemeta.json",
+#  "https://raw.githubusercontent.com/codemeta/codemeta/2.0/codemeta.jsonld")
+
+
+library("jsonld")
+
+
+# Example from https://github.com/digitalbazaar/jsonld.js#quick-examples
+doc <- '{
+"http://schema.org/name": "Manu Sporny",
+"http://schema.org/url": {"@id": "http://manu.sporny.org/"},
+"http://schema.org/image": {"@id": "http://manu.sporny.org/images/manu.png"}
+}'
+# Compact given a url to a context:
+out <- jsonld_compact(doc, "http://purl.org/codemeta/2.0")
+
+## Some systems / runs give:
+#Error in context_eval(join(src), private$context) :
+#  TypeError: Object #<Object> has no method 'match'

--- a/vignettes/C-validation-in-json-ld.Rmd
+++ b/vignettes/C-validation-in-json-ld.Rmd
@@ -72,8 +72,6 @@ By default, frames return all the input data, while our application may only be 
 
 
 ```{r}
-options(jsonld_use_accept = TRUE)
-
 frame <- '{
   "@context": "http://purl.org/codemeta/2.0",
   "@explicit": "true",

--- a/vignettes/C-validation-in-json-ld.Rmd
+++ b/vignettes/C-validation-in-json-ld.Rmd
@@ -42,7 +42,7 @@ Consider the following codemeta document:
 codemeta <- 
 '
 {
-  "@context": "https://doi.org/doi:10.5063/schema/codemeta-2.0",
+  "@context": "http://purl.org/codemeta/2.0",
   "@type": "SoftwareSourceCode",
   "name": "codemetar: Generate CodeMeta Metadata for R Packages",
   "datePublished":" 2017-05-20",
@@ -60,6 +60,11 @@ codemeta <-
 '
 ```
 
+
+```{r}
+jsonld::jsonld_compact(codemeta, "http://purl.org/codemeta/2.0")
+```
+
 ## Framing: subsetting data
 
 By default, frames return all the input data, while our application may only be interested in some subset.  Often it is sufficient just to ignore these additional terms: in the example above it's just as easy for our application to work with author elements whether or not we have dropped other elements such as `meta$version`.  To restrict a frame to returning only the nodes we explicitly mention, we can use the keyword `@explicit`:
@@ -67,8 +72,10 @@ By default, frames return all the input data, while our application may only be 
 
 
 ```{r}
+options(jsonld_use_accept = TRUE)
+
 frame <- '{
-  "@context": "https://doi.org/doi:10.5063/schema/codemeta-2.0",
+  "@context": "http://purl.org/codemeta/2.0",
   "@explicit": "true",
   "@type": "Person",
   "givenName": {},
@@ -106,9 +113,10 @@ We can use a frame with the special directive `"@embed": "@always"` to say that 
 
 ```{r}
 frame <- '{
-  "@context": "https://doi.org/doi:10.5063/schema/codemeta-2.0",
+  "@context": "http://purl.org/codemeta/2.0",
   "@embed": "@always"
 }'
+
 
 meta <- 
   jsonld_frame(codemeta, frame) %>%
@@ -138,7 +146,7 @@ that declares that the `buildInstructions` are included as text, which differs f
 codemeta <- 
 '
 {
-  "@context": "https://doi.org/doi:10.5063/schema/codemeta-2.0",
+  "@context": "https://purl.org/codemeta/2.0",
   "@type": "SoftwareSourceCode",
   "name": "codemetar: Generate CodeMeta Metadata for R Packages",
   "buildInstructions": { 
@@ -153,12 +161,12 @@ When we perform a framing or compaction operation, `buildInstructions` gets de-r
 
 ```{r}
 meta <-
-  jsonld_frame(codemeta, '{"@context": "https://doi.org/doi:10.5063/schema/codemeta-2.0"}') %>% 
+  jsonld_frame(codemeta, '{"@context": "https://purl.org/codemeta/2.0"}') %>% 
   fromJSON(codemeta, simplifyVector = FALSE) %>%  
   getElement("@graph") %>% getElement(1)    
 
 ## above is same as compacting:
-#jsonld_compact(codemeta, "https://doi.org/doi:10.5063/schema/codemeta-2.0") %>% 
+#jsonld_compact(codemeta, "http://purl.org/codemeta/2.0") %>% 
 #  fromJSON(codemeta, simplifyVector = FALSE)
 
 meta$buildInstructions


### PR DESCRIPTION
A possible proposal to address systematic content-negotiation failures in the DataCite DOI system; issue #34.  Note that JSON-LD algorithms also appear to rely on content-negotiation, as discussed in that thread.

purl.org is widely used for linked data urls.  Seems to provide a reasonably robust option provided it is maintained, but not a DOI :-(