### PR TITLE
Make extract_badges() robust to badges with line breaks

### DIFF
--- a/R/extract_badges.R
+++ b/R/extract_badges.R
@@ -1,7 +1,7 @@
 
 
 .extract_badges <- function(path){
-  txt <- readLines(path)
+  txt <- paste(readLines(path), collapse = " ")
   badges1 <- unlist(stringr::str_match_all(txt, "\\[!\\[\\]\\(.*?\\)\\]\\(.*?\\)"))
   badges2 <- unlist(stringr::str_match_all(txt, "\\[!\\[.*?\\]\\(.*?\\)\\]\\(.*?\\)"))
 

--- a/R/extract_badges.R
+++ b/R/extract_badges.R
@@ -1,7 +1,5 @@
 
-
-.extract_badges <- function(path){
-  txt <- paste(readLines(path), collapse = " ")
+.extract_badges_txt <- function(txt) {
   badges1 <- unlist(stringr::str_match_all(txt, "\\[!\\[\\]\\(.*?\\)\\]\\(.*?\\)"))
   badges2 <- unlist(stringr::str_match_all(txt, "\\[!\\[.*?\\]\\(.*?\\)\\]\\(.*?\\)"))
 
@@ -30,7 +28,11 @@
 #'
 #' @examples
 #' extract_badges(system.file("README.md", package = "codemetar"))
-extract_badges <- memoise::memoise(.extract_badges)
+extract_badges <- function(path) {
+  extract_badges_txt(paste(readLines(path), collapse = " "))
+}
+
+extract_badges_txt <- memoise::memoise(.extract_badges_txt)
 
 parse_md_badge <- function(badge){
   text <- stringr::str_match(badge, "\\[!\\[(.*?)\\]")[,2]

--- a/R/write_codemeta.R
+++ b/R/write_codemeta.R
@@ -13,6 +13,7 @@
 #'  to package root. Default guess is current dir.
 #' @param id identifier for the package, e.g. a DOI (or other resolvable URL)
 #' @param force_update Update guessed fields even if they are defined in an existing codemeta.json file
+#' @param use_git_hook Whether to create a pre-commit hook requiring codemeta.json to be updated when DESCRIPTION is changed.  Defaults to TRUE.
 #' @param verbose Whether to print messages indicating opinions e.g. when DESCRIPTION has no URL. See \code{\link{give_opinions}}.
 #' @param ...  additional arguments to \code{\link{write_json}}
 #' @details If pkg is a codemeta object, the function will attempt to
@@ -38,6 +39,7 @@ write_codemeta <- function(pkg = ".",
                            id = NULL,
                            force_update =
                              getOption("codemeta_force_update", TRUE),
+                           use_git_hook = TRUE,
                            verbose = TRUE,
                            ...) {
 
@@ -51,7 +53,7 @@ write_codemeta <- function(pkg = ".",
       # add the git pre-commit hook
       # https://github.com/r-lib/usethis/blob/master/inst/templates/readme-rmd-pre-commit.sh#L1
       # this is GPL-3 code
-      if(uses_git()){
+      if(uses_git() && use_git_hook){
         if(!file.exists(file.path(pkg, "codemeta.json"))){
           message("* Adding a pre-commit git hook ensuring that codemeta.json will be synchronized with DESCRIPTION") # nolint
           usethis::use_git_hook(

--- a/man/write_codemeta.Rd
+++ b/man/write_codemeta.Rd
@@ -5,8 +5,8 @@
 \title{write_codemeta}
 \usage{
 write_codemeta(pkg = ".", path = "codemeta.json", root = ".", id = NULL,
-  force_update = getOption("codemeta_force_update", TRUE), verbose = TRUE,
-  ...)
+  force_update = getOption("codemeta_force_update", TRUE),
+  use_git_hook = TRUE, verbose = TRUE, ...)
 }
 \arguments{
 \item{pkg}{package path to package root, or package name, or
@@ -20,6 +20,8 @@ to package root. Default guess is current dir.}
 \item{id}{identifier for the package, e.g. a DOI (or other resolvable URL)}
 
 \item{force_update}{Update guessed fields even if they are defined in an existing codemeta.json file}
+
+\item{use_git_hook}{Whether to create a pre-commit hook requiring codemeta.json to be updated when DESCRIPTION is changed.  Defaults to TRUE.}
 
 \item{verbose}{Whether to print messages indicating opinions e.g. when DESCRIPTION has no URL. See \code{\link{give_opinions}}.}
 


### PR DESCRIPTION
`extract_badges()` misses badges where the text breaks across lines, which will be the case for many badges with long alt-text because the standard `github_document` used for READMEs sets a max line width. This simple change collapses the README lines when reading in so as to make these detectable.