### PR TITLE
guess_readme() matches a single README file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,14 +30,18 @@ Authors@R:
       person(given = "Noam",
              family = "Ross",
              role = "ctb",
-             comment=c(ORCID = "0000-0002-2136-0000")),
+             comment = c(ORCID = "0000-0002-2136-0000")),
       person(given = "Arfon",
              family = "Smith",
              role = "ctb"),
-      person(given = "Jeroen", 
-             family = "Ooms", 
+      person(given = "Jeroen",
+             family = "Ooms",
              role = "ctb",
-             comment = c(ORCID = "0000-0002-4035-0289")))
+             comment = c(ORCID = "0000-0002-4035-0289")),
+      person(given = "Sebastian",
+             family = "Meyer",
+             role = "ctb",
+             comment = c(ORCID = "0000-0002-1791-9449")))
 Description: The 'Codemeta' Project defines a 'JSON-LD' format for describing
   software metadata, as detailed at <https://codemeta.github.io>. This package
   provides utilities to generate, parse, and modify 'codemeta.json' files 

--- a/R/guess_metadata.R
+++ b/R/guess_metadata.R
@@ -174,8 +174,7 @@ guess_github <- function(root = ".") {
     readme_url <- NULL
   }
 
-  contents <- dir(root)
-  readmes <- contents[grepl("[Rr][Ee][Aa][Dd][Mm][Ee]\\.R?md", contents)]
+  readmes <- dir(root, pattern = "^README\\.R?md$", ignore.case = TRUE)
   if(length(readmes) == 0){
     readme_path <- NULL
   }else{
@@ -187,6 +186,10 @@ guess_github <- function(root = ".") {
     }
   }
 
+  if(length(readme_path) > 1) { # README.md and ReadMe.md could both exist ...
+    ## silently use the first match (locale-dependent)
+    readme_path <- readme_path[1]
+  }
 
   return(list(readme_path = readme_path,
               readme_url = readme_url))

--- a/man/codemetar-package.Rd
+++ b/man/codemetar-package.Rd
@@ -61,6 +61,7 @@ Other contributors:
   \item Noam Ross (0000-0002-2136-0000) [contributor]
   \item Arfon Smith [contributor]
   \item Jeroen Ooms (0000-0002-4035-0289) [contributor]
+  \item Sebastian Meyer (0000-0002-1791-9449) [contributor]
 }
 
 }

--- a/tests/testthat/test-guess_metadata.R
+++ b/tests/testthat/test-guess_metadata.R
@@ -86,6 +86,24 @@ test_that("guess_readme", {
   testthat::expect_is(guess_readme(find.package("jsonlite")), "list")
 })
 
+test_that("guess_readme() matches a single README file", {
+  candidates <- c("README.Rmd", "readme.md", "README.Rmd~", "DO_NOT_README.md")
+  dir.create(tempdir <- tempfile("README"))
+  file.create(file.path(tempdir, candidates))
+  ## match README.Rmd then readme.md (use non-memoised function here)
+  for (i in 1:2) {
+    matched_README <- .guess_readme(tempdir)$readme_path
+    expect_length(matched_README, 1)
+    expect_identical(matched_README, file.path(tempdir, candidates[i]))
+    unlink(matched_README)
+  }
+  ## match none of the remaining candidates
+  matched_README <- .guess_readme(tempdir)$readme_path
+  expect_null(matched_README)
+  unlink(tempdir)
+})
+
+
 test_that("guess_releaseNotes", {
 
   guess_releaseNotes(".")


### PR DESCRIPTION
Fixes #189 and fixes #190.

`guess_readme()` now matches README.Rmd and README.md as well as their lower-/mixed-case variants (including readme.rmd which hasn't been matched before), but no other files such as README.Rmd~ or DO_NOT_README.md. The function either returns a single `readme_path` or `NULL`. I have added an appropriate test for this behaviour.

In the rare event where there exist multiple mixed-case README.md files on Unix-alikes, the function returns the first match (which is locale-dependent). I have decided not to warn about that since **codemetar** is generally non-verbose about its guesses.

I've also added myself to the DESCRIPTION using `desc::desc_add_me()` as suggested by @maelle (https://github.com/ropensci/codemetar/issues/190#issuecomment-428962067).