### PR TITLE
Fix "sameAs" link (if github:://user/repo is used in "Remotes:")

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,12 @@ Authors@R:
       person(given = "Sebastian",
              family = "Meyer",
              role = "ctb",
-             comment = c(ORCID = "0000-0002-1791-9449")))
+             comment = c(ORCID = "0000-0002-1791-9449")),
+      person(given = "Michael",
+             family = "Rustler",
+             role = "ctb",
+             comment = c(ORCID = "0000-0003-0647-7726"))
+             )
 Description: The 'Codemeta' Project defines a 'JSON-LD' format for describing
   software metadata, as detailed at <https://codemeta.github.io>. This package
   provides utilities to generate, parse, and modify 'codemeta.json' files 

--- a/R/parse_depends.R
+++ b/R/parse_depends.R
@@ -30,7 +30,8 @@ format_depend <- function(package, version, remote_provider){
   }
 
   if(remote_provider != ""){
-      dep$sameAs <- paste0("https://github.com/", remote_provider)
+    dep$sameAs <- paste0("https://github.com/",
+                         stringr::str_replace(remote_provider, "github::"))
   }
 
   return(dep)

--- a/R/parse_depends.R
+++ b/R/parse_depends.R
@@ -31,7 +31,7 @@ format_depend <- function(package, version, remote_provider){
 
   if(remote_provider != ""){
     dep$sameAs <- paste0("https://github.com/",
-                         stringr::str_replace(remote_provider, "github::"))
+                         stringr::str_remove(remote_provider, "github::"))
   }
 
   return(dep)


### PR DESCRIPTION
While it is be not needed to prefix Github as provider (as described in the [readme](https://github.com/r-lib/remotes#dependencies-on-github) of the remotes package), I prefer to be explicit about it.

However, using the latest codemetar version from the "dev" branch, the imported the "sameAs" link was not correct.

`[[3]]`
`[[3]]$@type`
`[1] "SoftwareApplication"`

`[[3]]$identifier`
`[1] "kwb.utils"`

`[[3]]$name`
`[1] "kwb.utils"`

`[[3]]$sameAs`
`[1] "https://github.com/github::KWB-R/kwb.utils"`

This should be fixed now! (only one line of code added this time) ;-)

Hope that helps! 
