### PR TITLE
Clean code in parse_depends.R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,16 @@ Authors@R:
       person(given = "Sebastian",
              family = "Meyer",
              role = "ctb",
-             comment = c(ORCID = "0000-0002-1791-9449")))
+             comment = c(ORCID = "0000-0002-1791-9449")),
+      person(given = "Michael",
+             family = "Rustler",
+             role = "ctb",
+             comment = c(ORCID = "0000-0003-0647-7726")),
+      person(given = "Hauke",
+             family = "Sonnenberg",
+             role = "ctb",
+             comment = c(ORCID = "0000-0001-9134-2871"))
+      )
 Description: The 'Codemeta' Project defines a 'JSON-LD' format for describing
   software metadata, as detailed at <https://codemeta.github.io>. This package
   provides utilities to generate, parse, and modify 'codemeta.json' files 

--- a/R/parse_depends.R
+++ b/R/parse_depends.R
@@ -38,13 +38,13 @@ get_sameAs <- function(provider, remote_provider, identifier) {
 
     if (provider$name == "Comprehensive R Archive Network (CRAN)") {
 
-      paste0("https://CRAN.R-project.org/package=", identifier)
+      sprintf("https://CRAN.R-project.org/package=%s", identifier)
 
     } else if (provider$name == "BioConductor") {
 
-      paste0(
-        "https://bioconductor.org/packages/release/bioc/html/",
-        identifier, ".html"
+      sprintf(
+        "https://bioconductor.org/packages/release/bioc/html/%s.html",
+        identifier
       )
 
     } # else NULL implicitly
@@ -54,7 +54,7 @@ get_sameAs <- function(provider, remote_provider, identifier) {
   # Overwrite result if remote_provider is given
   if (remote_provider != "") {
 
-    result <- paste0("https://github.com/", remote_provider)
+    result <- sprintf("https://github.com/%s", remote_provider)
   }
 
   result

--- a/R/parse_depends.R
+++ b/R/parse_depends.R
@@ -43,19 +43,16 @@ get_sameAs <- function(provider, remote_provider, identifier) {
       "https://github.com/%s"
   )
 
-  result <- if (! is.null(provider) && provider$name %in% names(urls)) {
-
-      sprintf(urls[provider$name], identifier)
-
-  } # else NULL implicitly
-
-  # Overwrite result if remote_provider is given
+  # The remote provider takes precedence over the non-remote provider
   if (remote_provider != "") {
 
-    result <- sprintf(urls["_GITHUB_"], remote_provider)
-  }
+    sprintf(urls["_GITHUB_"], remote_provider)
 
-  result
+  } else if (! is.null(provider) && provider$name %in% names(urls)) {
+
+    sprintf(urls[provider$name], identifier)
+
+  } # else NULL implicitly
 }
 
 

--- a/R/parse_depends.R
+++ b/R/parse_depends.R
@@ -20,33 +20,44 @@ format_depend <- function(package, version, remote_provider) {
   ## implemention could be better, e.g. support versioning
   #  dep$`@id` <- guess_dep_id(dep)
 
-  # CRAN canonical URL
-  if (! is.null(dep$provider)) {
+  sameAs <- get_sameAs(dep$provider, remote_provider, dep$identifier)
 
-    if (dep$provider$name == "Comprehensive R Archive Network (CRAN)") {
+  if (! is.null(sameAs)) {
 
-      dep$sameAs <- paste0(
-        "https://CRAN.R-project.org/package=", dep$identifier
-      )
-
-    } else {
-
-      if (dep$provider$name == "BioConductor") {
-
-        dep$sameAs <- paste0(
-          "https://bioconductor.org/packages/release/bioc/html/",
-          dep$identifier, ".html"
-        )
-      }
-    }
-  }
-
-  if (remote_provider != "") {
-
-    dep$sameAs <- paste0("https://github.com/", remote_provider)
+    dep$sameAs <- sameAs
   }
 
   return(dep)
+}
+
+## Get sameAs element for dep or NULL if not applicable
+get_sameAs <- function(provider, remote_provider, identifier) {
+
+  # CRAN canonical URL
+  result <- if (! is.null(provider)) {
+
+    if (provider$name == "Comprehensive R Archive Network (CRAN)") {
+
+      paste0("https://CRAN.R-project.org/package=", identifier)
+
+    } else if (provider$name == "BioConductor") {
+
+      paste0(
+        "https://bioconductor.org/packages/release/bioc/html/",
+        identifier, ".html"
+      )
+
+    } # else NULL implicitly
+
+  } # else NULL implicitly
+
+  # Overwrite result if remote_provider is given
+  if (remote_provider != "") {
+
+    result <- paste0("https://github.com/", remote_provider)
+  }
+
+  result
 }
 
 

--- a/R/parse_depends.R
+++ b/R/parse_depends.R
@@ -116,17 +116,18 @@ add_remote_to_dep <- function(package, remotes) {
 # helper to get system dependencies
 get_sys_links <- function(pkg, description = "") {
 
-  out1 <- jsonlite::fromJSON(
-    sprintf("https://sysreqs.r-hub.io/pkg/%s", pkg), simplifyVector = FALSE
+  # Define helper functions
+  to_url <- function(a, b) sprintf("https://sysreqs.r-hub.io/%s/%s", a, b)
+
+  get_json_names <- function(a, b) sapply(
+    X = jsonlite::fromJSON(to_url(a, b), simplifyVector = FALSE),
+    FUN = names
   )
 
-  out2 <- jsonlite::fromJSON(
-    sprintf("https://sysreqs.r-hub.io/map/%s", curl::curl_escape(description)),
-    simplifyVector = FALSE
-  )
-
-  sysreqs <- unique(c(sapply(out1, names), sapply(out2, names)))
-  sprintf("https://sysreqs.r-hub.io/get/%s", sysreqs)
+  to_url("get", unique(c(
+    get_json_names("pkg", pkg),
+    get_json_names("map", curl::curl_escape(description))
+  )))
 }
 
 

--- a/R/parse_depends.R
+++ b/R/parse_depends.R
@@ -46,7 +46,7 @@ get_sameAs <- function(provider, remote_provider, identifier) {
   # The remote provider takes precedence over the non-remote provider
   if (remote_provider != "") {
 
-    sprintf(urls["_GITHUB_"], remote_provider)
+    sprintf(urls["_GITHUB_"], stringr::str_remove(remote_provider, "github::"))
 
   } else if (! is.null(provider) && provider$name %in% names(urls)) {
 

--- a/R/parse_depends.R
+++ b/R/parse_depends.R
@@ -100,16 +100,9 @@ guess_dep_id <- function(dep) {
 
 add_remote_to_dep <- function(package, remotes) {
 
-  remote_provider <- remotes[grepl(paste0("/", package, "$"), remotes)]
+  remote_providers <- grep(paste0("/", package, "$"), remotes, value = TRUE)
 
-  if (length(remote_provider) == 0) {
-
-    ""
-
-  } else {
-
-    remote_provider
-  }
+  if (length(remote_providers)) remote_providers else ""
 }
 
 

--- a/R/parse_depends.R
+++ b/R/parse_depends.R
@@ -109,20 +109,22 @@ add_remote_to_dep <- function(package, remotes) {
 # helper to get system dependencies
 get_sys_links <- function(pkg, description = "") {
 
-  # Define helper functions
-  to_url <- function(a, b) sprintf("https://sysreqs.r-hub.io/%s/%s", a, b)
-
-  get_json_names <- function(a, b) sapply(
-    X = jsonlite::fromJSON(to_url(a, b), simplifyVector = FALSE),
-    FUN = names
-  )
-
-  to_url("get", unique(c(
-    get_json_names("pkg", pkg),
-    get_json_names("map", curl::curl_escape(description))
+  to_rhub_url("get", unique(c(
+    get_rhub_json_names("pkg", pkg),
+    get_rhub_json_names("map", curl::curl_escape(description))
   )))
 }
 
+to_rhub_url <- function(a, b) {
+  sprintf("https://sysreqs.r-hub.io/%s/%s", a, b)
+}
+
+get_rhub_json_names <- function(a, b) {
+  sapply(
+    X = jsonlite::fromJSON(to_rhub_url(a, b), simplifyVector = FALSE),
+    FUN = names
+  )
+}
 
 format_sys_req <- function(url) {
 

--- a/R/parse_depends.R
+++ b/R/parse_depends.R
@@ -34,27 +34,25 @@ format_depend <- function(package, version, remote_provider) {
 get_sameAs <- function(provider, remote_provider, identifier) {
 
   # CRAN canonical URL
-  result <- if (! is.null(provider)) {
+  urls <- c(
+    "Comprehensive R Archive Network (CRAN)" =
+      "https://CRAN.R-project.org/package=%s",
+    "BioConductor" =
+      "https://bioconductor.org/packages/release/bioc/html/%s.html",
+    "_GITHUB_" =
+      "https://github.com/%s"
+  )
 
-    if (provider$name == "Comprehensive R Archive Network (CRAN)") {
+  result <- if (! is.null(provider) && provider$name %in% names(urls)) {
 
-      sprintf("https://CRAN.R-project.org/package=%s", identifier)
-
-    } else if (provider$name == "BioConductor") {
-
-      sprintf(
-        "https://bioconductor.org/packages/release/bioc/html/%s.html",
-        identifier
-      )
-
-    } # else NULL implicitly
+      sprintf(urls[provider$name], identifier)
 
   } # else NULL implicitly
 
   # Overwrite result if remote_provider is given
   if (remote_provider != "") {
 
-    result <- sprintf("https://github.com/%s", remote_provider)
+    result <- sprintf(urls["_GITHUB_"], remote_provider)
   }
 
   result

--- a/R/parse_depends.R
+++ b/R/parse_depends.R
@@ -1,13 +1,17 @@
 ## internal method for parsing a list of package dependencies into pkg URLs
 
-format_depend <- function(package, version, remote_provider){
-  dep <- list("@type" = "SoftwareApplication",
-              identifier = package,
-              ## FIXME technically the name includes the title
-              name = package)
+format_depend <- function(package, version, remote_provider) {
+
+  dep <- list(
+    "@type" = "SoftwareApplication",
+    identifier = package,
+    ## FIXME technically the name includes the title
+    name = package
+  )
 
   ## Add Version if available
-  if (version != "*"){
+  if (version != "*") {
+
     dep$version <- version
   }
 
@@ -17,82 +21,118 @@ format_depend <- function(package, version, remote_provider){
   #  dep$`@id` <- guess_dep_id(dep)
 
   # CRAN canonical URL
-  if(!is.null(dep$provider)){
-    if(dep$provider$name == "Comprehensive R Archive Network (CRAN)"){
-      dep$sameAs <- paste0("https://CRAN.R-project.org/package=",
-                           dep$identifier)
-    }else{
-      if(dep$provider$name == "BioConductor"){
-        dep$sameAs <- paste0("https://bioconductor.org/packages/release/bioc/html/",
-                             dep$identifier, ".html")
+  if (! is.null(dep$provider)) {
+
+    if (dep$provider$name == "Comprehensive R Archive Network (CRAN)") {
+
+      dep$sameAs <- paste0(
+        "https://CRAN.R-project.org/package=", dep$identifier
+      )
+
+    } else {
+
+      if (dep$provider$name == "BioConductor") {
+
+        dep$sameAs <- paste0(
+          "https://bioconductor.org/packages/release/bioc/html/",
+          dep$identifier, ".html"
+        )
       }
     }
   }
 
-  if(remote_provider != ""){
-      dep$sameAs <- paste0("https://github.com/", remote_provider)
+  if (remote_provider != "") {
+
+    dep$sameAs <- paste0("https://github.com/", remote_provider)
   }
 
   return(dep)
-
 }
+
 
 parse_depends <- function(deps) {
 
-  purrr::pmap(list(deps$package, deps$version,
-                deps$remote_provider),
-  format_depend)
+  purrr::pmap(
+    list(deps$package, deps$version, deps$remote_provider),
+    format_depend
+  )
 }
 
 
-## FIXME these are not version-specific. That's often not accurate, though does reflect the CRAN assumption that you must be compatible with the latest version...
+## FIXME these are not version-specific. That's often not accurate, though does
+## reflect the CRAN assumption that you must be compatible with the latest
+## version...
 guess_dep_id <- function(dep) {
+
   if (dep$name == "R") {
+
     ## FIXME No good identifier for R, particularly none for specific version
     id <- "https://www.r-project.org"
+
   } else if (is.null(dep$provider)) {
+
     id <- NULL
+
   } else if (grepl("cran.r-project.org", dep$provider$url)) {
+
     id <- paste0(dep$provider$url, "/web/packages/", dep$identifier)
+
   } else if (grepl("www.bioconductor.org", dep$provider$url)) {
-    id <-
-      paste0(dep$provider$url,
-             "/packages/release/bioc/html/",
-             dep$identifier,
-             ".html")
+
+    id <- paste0(
+      dep$provider$url, "/packages/release/bioc/html/", dep$identifier, ".html"
+    )
+
   } else {
+
     id <- NULL
   }
 
   id
-
 }
 
-add_remote_to_dep <- function(package, remotes){
-  remote_provider <- remotes[grepl(paste0("/", package, "$"),
-                                   remotes)]
-  if(length(remote_provider) == 0){
+
+add_remote_to_dep <- function(package, remotes) {
+
+  remote_provider <- remotes[grepl(paste0("/", package, "$"), remotes)]
+
+  if (length(remote_provider) == 0) {
+
     ""
-  }else{
+
+  } else {
+
     remote_provider
   }
 }
 
 
 # helper to get system dependencies
-get_sys_links <- function(pkg, description = ""){
-  out1 <- jsonlite::fromJSON(sprintf("https://sysreqs.r-hub.io/pkg/%s", pkg), simplifyVector = FALSE)
-  out2 <- jsonlite::fromJSON(sprintf("https://sysreqs.r-hub.io/map/%s", curl::curl_escape(description)), simplifyVector = FALSE)
+get_sys_links <- function(pkg, description = "") {
+
+  out1 <- jsonlite::fromJSON(
+    sprintf("https://sysreqs.r-hub.io/pkg/%s", pkg), simplifyVector = FALSE
+  )
+
+  out2 <- jsonlite::fromJSON(
+    sprintf("https://sysreqs.r-hub.io/map/%s", curl::curl_escape(description)),
+    simplifyVector = FALSE
+  )
+
   sysreqs <- unique(c(sapply(out1, names), sapply(out2, names)))
   sprintf("https://sysreqs.r-hub.io/get/%s", sysreqs)
 }
 
-format_sys_req <- function(url){
-  list("@type" = "SoftwareApplication",
-       identifier = url)
+
+format_sys_req <- function(url) {
+
+  list("@type" = "SoftwareApplication", identifier = url)
 }
 
-parse_sys_reqs <- function(pkg, sys_reqs){
+
+parse_sys_reqs <- function(pkg, sys_reqs) {
+
   urls <- get_sys_links(pkg, description = sys_reqs)
+
   purrr::map(urls, format_sys_req)
 }

--- a/tests/testthat/test-parse_depends.R
+++ b/tests/testthat/test-parse_depends.R
@@ -34,6 +34,30 @@ testthat::test_that("Test the various cases for dependencies", {
 
 })
 
+test_that("get_sameAs() works as expected", {
+
+  expect_null(get_sameAs(NULL, "", "my_package"))
+
+  expect_error(get_sameAs("unknown", "", "my_package"))
+
+  expect_null(get_sameAs(list(name = "unknown"), "", "my_package"))
+
+  provider_1 <- list(name = "Comprehensive R Archive Network (CRAN)")
+  provider_2 <- list(name = "BioConductor")
+
+  url_1 <- "https://CRAN.R-project.org/package=my_package"
+  url_2 <- "https://bioconductor.org/packages/release/bioc/html/my_package.html"
+  url_3 <- "https://github.com/my_remote_package"
+
+  expect_equal(url_1, get_sameAs(provider_1, "", "my_package"))
+  expect_equal(url_2, get_sameAs(provider_2, "", "my_package"))
+
+  expect_equal(url_3, get_sameAs(NULL, "my_remote_package"))
+  expect_equal(url_3, get_sameAs("does_not_matter", "my_remote_package"))
+  expect_equal(url_3, get_sameAs(NULL, "my_remote_package", "does_not_matter"))
+  expect_equal(url_3, get_sameAs(NULL, "github::my_remote_package"))
+})
+
 testthat::test_that("Test the various cases for ids (NOT used currently)", {
 
   # a <- guess_dep_id(parse_depends("a4")[[1]])  # BIOC provider


### PR DESCRIPTION
Hello, 
I propose some slight cleaning of the code in parse_depends.R to which my colleague Michael proposed one new line in his pull request #200. You can follow my changes step by step by looking at my commits in the branch clean/parse_depends. My main motivation was to avoid code duplication and to separate the definition of URLs from the logic in if-else-statements. I added some tests that check the proper assignment of URLs. Michael's change was reintegrated with my commit 7e9157f. I hope that you agree with my changes and that I can help you make your code a bit cleaner. I still see much room of improvement. Are you interested in further collaboration?
Kind regards,
Hauke