### PR TITLE
Fix typo in announced argument name

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 
 * The CodeRepository URL is now cleaned a bit (removing direct link to the README).
 
-* `write_codemeta()` gains a new argument `use_githook` to make the creation of a DESCRIPTION/codemeta.json git pre-commit hook optional.
+* `write_codemeta()` gains a new argument `use_git_hook` to make the creation of a DESCRIPTION/codemeta.json git pre-commit hook optional.
 
 * `create_codemeta()` and `write_codemeta()` gain a new argument `use_filesize` to make the building of the package to get its size optional.
 


### PR DESCRIPTION
This is a bit delicate, because the NEWS is already announced. Maybe renaming the argument itself in https://github.com/ropensci/codemetar/blob/77fc0943a379d27915bb6a8cb9b37cb3349c05da/R/write_codemeta.R#L19-L64 (anywhere before `usethis::`) would be less disruptive?