### PR TITLE
Fix for detecting the ropensci review badge

### DIFF
--- a/R/codemeta_readme.R
+++ b/R/codemeta_readme.R
@@ -53,7 +53,7 @@ ropensci_reviews <- memoise::memoise(.ropensci_reviews)
 # guess_ropensci_review --------------------------------------------------------
 guess_ropensci_review <- function(readme) {
 
-  url <- "github.com/ropensci/onboarding/issues/"
+  url <- "github.com/ropensci/onboarding/issues/|github.com/ropensci/software-review/issues/"
 
   badges <- get_badge_links_matching(readme, url)
 

--- a/R/codemeta_readme.R
+++ b/R/codemeta_readme.R
@@ -28,6 +28,12 @@ get_badge_links_matching <- function(readme, pattern) {
   # else NULL implicitly
 }
 
+# get_badge_links_matching -----------------------------------------------------
+which_url_matches_badge_link <- function(readme, patterns) {
+  badges <- extract_badges(readme)
+  names(which(vapply(patterns, function(z) any(grepl(z, x = badges$link)), logical(1))))
+}
+
 # get_pkg_name -----------------------------------------------------------------
 get_pkg_name <- function(entry) {
 
@@ -53,21 +59,23 @@ ropensci_reviews <- memoise::memoise(.ropensci_reviews)
 # guess_ropensci_review --------------------------------------------------------
 guess_ropensci_review <- function(readme) {
 
-  url <- "github.com/ropensci/onboarding/issues/|github.com/ropensci/software-review/issues/"
+  url <- "github.com/ropensci/onboarding/issues/"
+  url2 <- "github.com/ropensci/software-review/issues/"
 
-  badges <- get_badge_links_matching(readme, url)
+  badges <- get_badge_links_matching(readme, paste0(url, "|", url2))
 
   if (is.null(badges)) {
 
     return(NULL)
   }
 
-  review <- as.numeric(stringr::str_remove(badges, paste0(".*https://", url)))
+  url_m <- which_url_matches_badge_link(readme, c(url, url2))
+  review <- as.numeric(stringr::str_remove(badges, paste0(".*https://", url_m)))
 
   if (review %in% ropensci_reviews()$review) {
 
     list("@type" = "Review",
-         "url" = paste0("https://", url, review),
+         "url" = paste0("https://", url_m, review),
          "provider" = "http://ropensci.org")
   }
   # else NULL implicitly


### PR DESCRIPTION
Stef pointed out that some pkgs that have gone through review are not in our website's pkgs page. Seems it was related to the switch of our review repo from `/onboarding` to `/software-review`

this fixes it, but there may be a more elegant way to do it