### PR TITLE
Add tempdir() to avoid unwanted package file writing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,7 +49,11 @@ Authors@R:
       person(given = "Hauke",
              family = "Sonnenberg",
              role = "ctb",
-             comment = c(ORCID = "0000-0001-9134-2871"))
+             comment = c(ORCID = "0000-0001-9134-2871")),
+      person(given = "Sebastian",
+             family = "Kreutzer",
+             role = "ctb",
+             comment = c(ORCID = "0000-0002-0734-2199"))
       )
 Description: The 'Codemeta' Project defines a 'JSON-LD' format for describing
   software metadata, as detailed at <https://codemeta.github.io>. This package

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -70,7 +70,6 @@ Depends: R (>= 3.0.0)
 Imports: 
     jsonlite (>= 1.6),
     git2r,
-    pkgbuild,
     memoise,
     methods,
     stats,

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
 * update test suite to reflect newly available metadata.
 * `write_codemeta()` and `create_codemeta()`: `use_filesize = FALSE` is now the default and
 the estimation of the file size does not leave any more unwanted files behind [PR #239](https://github.com/ropensci/codemetar/pull/239). 
+* `write_codemeta()`: the default of argument `use_git_hook` is now `FALSE` to avoid an 
+unwanted alteration of the user's git environment (#240)[https://github.com/ropensci/codemetar/issues/240].
 
 # codemetar 0.1.7 2018-12
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 * `write_codemeta()` and `create_codemeta()`: `use_filesize = FALSE` is now the default and
 the estimation of the file size does not leave any more unwanted files behind [PR #239](https://github.com/ropensci/codemetar/pull/239). 
 * `write_codemeta()`: the default of argument `use_git_hook` is now `FALSE` to avoid an 
-unwanted alteration of the user's git environment (#240)[https://github.com/ropensci/codemetar/issues/240].
+unwanted alteration of the user's git environment [issue #240](https://github.com/ropensci/codemetar/issues/240).
 
 # codemetar 0.1.7 2018-12
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,10 +5,11 @@
 * address internet timeout issues
 * tidy source code
 * update test suite to reflect newly available metadata.
-* `write_codemeta()` and `create_codemeta()`: `use_filesize = FALSE` is now the default and
-the estimation of the file size does not leave any more unwanted files behind [PR #239](https://github.com/ropensci/codemetar/pull/239). 
+* `write_codemeta()` and `create_codemeta()`: `use_filesize = FALSE` is now the default and the estimation of the file size does not leave any more unwanted files behind [PR #239](https://github.com/ropensci/codemetar/pull/239). Furthermore, the way the file size is calculated changed: Before we used the size of the package built with `pkgbuild::build()`, which took rather long. Now the size is calculated based on the source files minus files excluded via  
+ `.Rbuildignore` (if such a file exists).
 * `write_codemeta()`: the default of argument `use_git_hook` is now `FALSE` to avoid an 
 unwanted alteration of the user's git environment [issue #240](https://github.com/ropensci/codemetar/issues/240).
+* Package dependency to 'pkgbuild' has been dropped.
 
 # codemetar 0.1.7 2018-12
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@
 * address internet timeout issues
 * tidy source code
 * update test suite to reflect newly available metadata.
+* `write_codemeta()` and `create_codemeta()`: `use_filesize = FALSE` is now the default and
+the estimation of the file size does not leave any more unwanted files behind [PR #239](https://github.com/ropensci/codemetar/pull/239). 
 
 # codemetar 0.1.7 2018-12
 

--- a/R/create_codemeta.R
+++ b/R/create_codemeta.R
@@ -18,7 +18,7 @@ create_codemeta <- function(
   pkg = ".",
   root = ".",
   id = NULL,
-  use_filesize = TRUE,
+  use_filesize = FALSE,
   force_update =
     getOption("codemeta_force_update", TRUE),
   verbose = TRUE,

--- a/R/guess_other_metadata.R
+++ b/R/guess_other_metadata.R
@@ -39,7 +39,7 @@ guess_fileSize <- function(root = ".") {
   }
 
   file_path <- try(silent = TRUE, pkgbuild::build(
-    root, vignettes = FALSE, manual = FALSE, quiet = TRUE
+    root, dest_path = tempdir(), vignettes = FALSE, manual = FALSE, quiet = TRUE
   ))
 
   if (inherits(file_path, "try-error")) {

--- a/R/guess_other_metadata.R
+++ b/R/guess_other_metadata.R
@@ -20,34 +20,54 @@ guess_releaseNotes <- function(root = ".") {
 }
 
 # guess_fileSize ---------------------------------------------------------------
-guess_fileSize <- function(root = ".") {
-
-  ## No root, no file size
-  if (is.null(root)) {
-
+#' @title Estimate the File Size of the Software
+#'
+#' @description The function makes a rough estimation of the size of the
+#' R package using the base R function [file.size]. Files in `.Rbuildignore` are
+#' exclude. Please note that this estimation does not necessarily reflect the installed size
+#' of the package.
+#'
+#' @param root the root file path
+#'
+#' @param .ignore optional vector of regular expresssions that will be ignore when the file
+#' size is guessed
+#'
+#' @seealso [base::file.size]
+#'
+#' @examples
+#'
+#' guess_fileSize()
+#'
+#' @md
+#' @noRd
+guess_fileSize <- function(root = ".", .ignore = NULL) {
+  ## no root, no file size
+  if (is.null(root))
     return(NULL)
+
+  ## check for .Rbuildignore, everything listed should be excluded since
+  ## it will not become part of the final package
+  if (file.exists(".Rbuildignore") && is.null(.ignore)){
+    .ignore <- readLines(normalizePath(paste0(root,"Rbuildignore")), warn = FALSE)
+
+  }else{
+    .ignore <- " "
+
   }
 
-  ## Look for files 1. Meta, 2. DESCRIPTION
-  file_exists <- file.exists(file.path(root, c("Meta", "DESCRIPTION")))
-
-  ## Meta exists -> cannot build (or read file size?) on an already installed
-  ## package
-  if (file_exists[1] || ! file_exists[2]) {
-
-    return(NULL)
-  }
-
-  file_path <- try(silent = TRUE, pkgbuild::build(
-    root, dest_path = tempdir(), vignettes = FALSE, manual = FALSE, quiet = TRUE
+  ## grep all files of interest (exclude hidden files)
+  files <- normalizePath(list.files(
+    path = normalizePath(root),
+    recursive = TRUE,
+    full.names = TRUE,
+    all.files = FALSE
   ))
 
-  if (inherits(file_path, "try-error")) {
+  ## kick-out all files that do not belong to the R package
+  files <-
+    files[!grepl(paste(.ignore, collapse = "|"), files, perl = TRUE)]
 
-    NULL
-
-  } else {
-
-    paste0(file.size(file_path) / 1e3, "KB")
-  }
+  ## estimate total size
+  paste0(sum(file.size(files)) / 1e3, "KB")
 }
+

--- a/R/write_codemeta.R
+++ b/R/write_codemeta.R
@@ -18,7 +18,8 @@
 #' @param force_update Update guessed fields even if they are defined in an
 #'   existing codemeta.json file
 #' @param use_git_hook Whether to create a pre-commit hook requiring
-#'   codemeta.json to be updated when DESCRIPTION is changed.  Defaults to TRUE.
+#'   codemeta.json to be updated when DESCRIPTION is changed. Default is \code{FALSE} to avoid
+#'   an unwanted alteration of the user's git environment.
 #' @param verbose Whether to print messages indicating opinions e.g. when
 #'   DESCRIPTION has no URL. See \code{\link{give_opinions}}.
 #' @param ...  additional arguments to \code{\link{write_json}}
@@ -41,7 +42,7 @@
 #' }
 write_codemeta <- function(
   pkg = ".", path = "codemeta.json", root = ".", id = NULL, use_filesize = FALSE,
-  force_update = getOption("codemeta_force_update", TRUE), use_git_hook = TRUE,
+  force_update = getOption("codemeta_force_update", TRUE), use_git_hook = FALSE,
   verbose = TRUE, ...
 ) {
 

--- a/R/write_codemeta.R
+++ b/R/write_codemeta.R
@@ -13,7 +13,8 @@
 #'   root. Default guess is current dir.
 #' @param id identifier for the package, e.g. a DOI (or other resolvable URL)
 #' @param use_filesize whether to try adding a filesize by using
-#'   \code{pkgbuild::build()}.
+#'   \code{pkgbuild::build()}. Note: Depending on the package this option may add considerable processing
+#'   time.
 #' @param force_update Update guessed fields even if they are defined in an
 #'   existing codemeta.json file
 #' @param use_git_hook Whether to create a pre-commit hook requiring
@@ -39,7 +40,7 @@
 #' write_codemeta("codemetar", path = "example_codemetar_codemeta.json")
 #' }
 write_codemeta <- function(
-  pkg = ".", path = "codemeta.json", root = ".", id = NULL, use_filesize = TRUE,
+  pkg = ".", path = "codemeta.json", root = ".", id = NULL, use_filesize = FALSE,
   force_update = getOption("codemeta_force_update", TRUE), use_git_hook = TRUE,
   verbose = TRUE, ...
 ) {

--- a/R/write_codemeta.R
+++ b/R/write_codemeta.R
@@ -12,9 +12,8 @@
 #' @param root if pkg is a codemeta object, optionally give the path to package
 #'   root. Default guess is current dir.
 #' @param id identifier for the package, e.g. a DOI (or other resolvable URL)
-#' @param use_filesize whether to try adding a filesize by using
-#'   \code{pkgbuild::build()}. Note: Depending on the package this option may add considerable processing
-#'   time.
+#' @param use_filesize whether to try to estimating and adding a filesize by using
+#'   \code{base::files.ize()}. Files in \code{.Rbuildignore} are ignored.
 #' @param force_update Update guessed fields even if they are defined in an
 #'   existing codemeta.json file
 #' @param use_git_hook Whether to create a pre-commit hook requiring

--- a/man/codemetar-package.Rd
+++ b/man/codemetar-package.Rd
@@ -64,6 +64,7 @@ Other contributors:
   \item Sebastian Meyer (0000-0002-1791-9449) [contributor]
   \item Michael Rustler (0000-0003-0647-7726) [contributor]
   \item Hauke Sonnenberg (0000-0001-9134-2871) [contributor]
+  \item Sebastian Kreutzer (0000-0002-0734-2199) [contributor]
 }
 
 }

--- a/man/create_codemeta.Rd
+++ b/man/create_codemeta.Rd
@@ -5,7 +5,7 @@
 \title{create_codemeta}
 \usage{
 create_codemeta(pkg = ".", root = ".", id = NULL,
-  use_filesize = TRUE,
+  use_filesize = FALSE,
   force_update = getOption("codemeta_force_update", TRUE),
   verbose = TRUE, ...)
 }
@@ -19,7 +19,8 @@ root. Default guess is current dir.}
 \item{id}{identifier for the package, e.g. a DOI (or other resolvable URL)}
 
 \item{use_filesize}{whether to try adding a filesize by using
-\code{pkgbuild::build()}.}
+\code{pkgbuild::build()}. Note: Depending on the package this option may add considerable processing
+time.}
 
 \item{force_update}{Update guessed fields even if they are defined in an
 existing codemeta.json file}

--- a/man/create_codemeta.Rd
+++ b/man/create_codemeta.Rd
@@ -18,9 +18,8 @@ root. Default guess is current dir.}
 
 \item{id}{identifier for the package, e.g. a DOI (or other resolvable URL)}
 
-\item{use_filesize}{whether to try adding a filesize by using
-\code{pkgbuild::build()}. Note: Depending on the package this option may add considerable processing
-time.}
+\item{use_filesize}{whether to try to estimating and adding a filesize by using
+\code{base::files.ize()}. Files in \code{.Rbuildignore} are ignored.}
 
 \item{force_update}{Update guessed fields even if they are defined in an
 existing codemeta.json file}

--- a/man/write_codemeta.Rd
+++ b/man/write_codemeta.Rd
@@ -7,7 +7,7 @@
 write_codemeta(pkg = ".", path = "codemeta.json", root = ".",
   id = NULL, use_filesize = FALSE,
   force_update = getOption("codemeta_force_update", TRUE),
-  use_git_hook = TRUE, verbose = TRUE, ...)
+  use_git_hook = FALSE, verbose = TRUE, ...)
 }
 \arguments{
 \item{pkg}{package path to package root, or package name, or description file
@@ -28,7 +28,8 @@ time.}
 existing codemeta.json file}
 
 \item{use_git_hook}{Whether to create a pre-commit hook requiring
-codemeta.json to be updated when DESCRIPTION is changed.  Defaults to TRUE.}
+codemeta.json to be updated when DESCRIPTION is changed. Default is \code{FALSE} to avoid
+an unwanted alteration of the user's git environment.}
 
 \item{verbose}{Whether to print messages indicating opinions e.g. when
 DESCRIPTION has no URL. See \code{\link{give_opinions}}.}

--- a/man/write_codemeta.Rd
+++ b/man/write_codemeta.Rd
@@ -20,9 +20,8 @@ root. Default guess is current dir.}
 
 \item{id}{identifier for the package, e.g. a DOI (or other resolvable URL)}
 
-\item{use_filesize}{whether to try adding a filesize by using
-\code{pkgbuild::build()}. Note: Depending on the package this option may add considerable processing
-time.}
+\item{use_filesize}{whether to try to estimating and adding a filesize by using
+\code{base::files.ize()}. Files in \code{.Rbuildignore} are ignored.}
 
 \item{force_update}{Update guessed fields even if they are defined in an
 existing codemeta.json file}

--- a/man/write_codemeta.Rd
+++ b/man/write_codemeta.Rd
@@ -5,7 +5,7 @@
 \title{write_codemeta}
 \usage{
 write_codemeta(pkg = ".", path = "codemeta.json", root = ".",
-  id = NULL, use_filesize = TRUE,
+  id = NULL, use_filesize = FALSE,
   force_update = getOption("codemeta_force_update", TRUE),
   use_git_hook = TRUE, verbose = TRUE, ...)
 }
@@ -21,7 +21,8 @@ root. Default guess is current dir.}
 \item{id}{identifier for the package, e.g. a DOI (or other resolvable URL)}
 
 \item{use_filesize}{whether to try adding a filesize by using
-\code{pkgbuild::build()}.}
+\code{pkgbuild::build()}. Note: Depending on the package this option may add considerable processing
+time.}
 
 \item{force_update}{Update guessed fields even if they are defined in an
 existing codemeta.json file}

--- a/tests/testthat/test-guess_metadata.R
+++ b/tests/testthat/test-guess_metadata.R
@@ -105,11 +105,15 @@ test_that("fileSize", {
   skip_on_cran()
   skip_if_offline()
 
+  ## should be NULL if root == NULL
   expect_null(guess_fileSize(NULL))
-  expect_null(guess_fileSize("."))
-  ## expect_null?
-  f <- system.file(".", package="codemetar")
-  expect_null(guess_fileSize(f))
+
+  ## this should just work fine
+  expect_is(guess_fileSize("."), "character")
+
+  ## test argument .ignore
+  expect_is(guess_fileSize(".", .ignore = " "), "character")
+
 })
 
 test_that("add_github_topics",{


### PR DESCRIPTION
## Background

Calling `create_codemeta(use_filesize = TRUE)` (the default) uses `pkgbuild::build()` to build the package and estimates its file size. 

Unfortunately, it does not clean-up after and leaves unwanted files behind in the user's home filespace (here in the parent directory). While doing so, the package violates the [CRAN policy](https://cran.r-project.org/web/packages/policies.html): 
 
>  Packages should not write in the user’s home filespace (including clipboards)

## Solution

`pkgbuild::build()` provides the argument `dest_path`. This argument can be set to `tempdir()` to avoid the trouble, which is the solution I propose with my PR.

## Further remarks

Besides it might be reasonable to make `create_codemeta(use_filesize = FALSE)` the default (not part of my PR). If a package contains a lot of code to compile it takes quite some time, and the reason for the waiting time is not immanently obvious.  
