### PR TITLE
alter codeRepository assignment code and guess_github

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * Fix for detecting rOpenSci review badge (@sckott, #236)
 * Fix extraction of orcid when composite comment (@billy34, #231)
 * Fix bug in crosswalking (#243)
+* Alter `create_codemeta` codeRepository assignment; force `guess_github` to be called if `cm$codeRepository` does not match a pattern of `https?://github.com`, which should catch any URLs  that are not source repositories. `guess_github` now matches on `git://github.com/` in addition to `git@github.com` (#247)
 
 # codemetar 0.1.8 2019-05
 

--- a/R/create_codemeta.R
+++ b/R/create_codemeta.R
@@ -73,7 +73,9 @@ create_codemeta <- function(
   cm <- codemeta_description(file.path(root, "DESCRIPTION"), id = id, cm)
 
   ## Guess these only if not set in current codemeta
-  if ((is.null(cm$codeRepository) && force_update)) {
+  matches_gh <- grepl("https?://github.com.+", cm$codeRepository)
+  if (length(matches_gh) == 0) matches_gh <- FALSE
+  if ((is.null(cm$codeRepository) && force_update) || !matches_gh) {
 
     cm$codeRepository <- guess_github(root)
   }

--- a/R/guess_github_metadata.R
+++ b/R/guess_github_metadata.R
@@ -23,7 +23,7 @@ guess_github <- function(root = ".") {
     remote_urls() %>%
     grep(pattern = "github", value = TRUE) %>%
     getElement(1) %>%
-    gsub(pattern = "git@github.com:", replacement = "https://github.com/") %>%
+    gsub(pattern = "git@github.com:|git://github.com/", replacement = "https://github.com/") %>%
     gsub(pattern = "\\.git$", replacement = "")
 }
 


### PR DESCRIPTION
At least one ropensci repo does not have the github src url in its URL field in DESCRIPTION https://github.com/YuLab-SMU/treeio/blob/master/DESCRIPTION#L40 

This caused the makeregistry script on our registry server to use the current url in that field, which causes problems in jeroen's cranlike flow because it's a url for a book, not the source code. 

this PR 

1. alters the block of code in `create_codemeta` where codeRepository is assigned. it will force the guess_github to be called if `cm$codeRepository` does not match a pattern of `https?://github.com`, which should catch any URLs  that are not source repositories
2. in `guess_github`, i added `git://github.com/` to the gsub because the remote for treeio was of that pattern rather than `git@github.com`