### PR TITLE
updates README when actually wanting to update the README

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # codemetar (development version)
 
+* Bug fix: the README information is now updated by codemeta_readme(). Previously if e.g. a developmentStatus had been set previously, it was never updated.
+
 * Code cleaning following the book Martin, Robert C. Clean code: a handbook of agile software craftsmanship. Pearson Education, 2009. (@hsonne, #201, #202, #204, #205, #206, #207, #209, #210, #211, #212, #216, #218, #219, #220, #221).
 * Fix for detecting rOpenSci review badge (@sckott, #236)
 * Fix extraction of orcid when composite comment (@billy34, #231)

--- a/R/codemeta_readme.R
+++ b/R/codemeta_readme.R
@@ -149,8 +149,8 @@ guess_readme <- memoise::memoise(.guess_readme)
 codemeta_readme <- function(readme, codemeta) {
 
   codemeta %>%
-    set_element_if_null("contIntegration", guess_ci(readme)) %>%
-    set_element_if_null("developmentStatus", guess_devStatus(readme)) %>%
-    set_element_if_null("review", guess_ropensci_review(readme))
+    set_element("contIntegration", guess_ci(readme)) %>%
+    set_element("developmentStatus", guess_devStatus(readme)) %>%
+    set_element("review", guess_ropensci_review(readme))
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -151,18 +151,17 @@ is_package <- function(path) {
   all(c("DESCRIPTION", "NAMESPACE", "man", "R") %in% dir(path))
 }
 
-# set_element_if_null ----------------------------------------------------------
-set_element_if_null <- function(x, element, value) {
+# set_element ----------------------------------------------
+set_element <- function(x, element, value) {
 
   stopifnot(is.list(x))
 
-  if (is.null(x[[element]])) {
-
-    x[[element]] <- value
-  }
+  x[[element]] <- value
 
   x
+
 }
+
 
 # fails ------------------------------------------------------------------------
 #' Does the Evaluation of an Expression Fail?


### PR DESCRIPTION
codemeta_readme() is called only when force_update is TRUE so one should _replace_ elements always, not only when they're NULL.