### PR TITLE
Repos

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,7 +61,7 @@ URL: https://github.com/ropensci/codemetar, https://docs.ropensci.org/codemetar
 BugReports: https://github.com/ropensci/codemetar/issues
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.0
 Depends: R (>= 3.0.0)
 Imports: 
     jsonlite (>= 1.6),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -87,7 +87,8 @@ Imports:
     magrittr,
     glue,
     pingr,
-    urltools
+    urltools,
+    remotes
 Suggests: 
     testthat (>= 2.1.0),
     jsonld,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -78,7 +78,6 @@ Imports:
     tibble,
     crul,
     gh,
-    stringr,
     sessioninfo,
     purrr,
     curl,

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,9 +2,7 @@
 
 ## Enhancements
 
-* codemetar can now recognize an URL from GitHub, GitLab, Bitbucket, R-Forge among several URLs in DESCRIPTION, to assign it to codeRepository. If there's only one URL in DESCRIPTION, it is assumed it is a codeRepository, no matter its domain.
-
-* Alter `create_codemeta` codeRepository assignment; force `guess_github` to be called if `cm$codeRepository` does not match a pattern of `https?://github.com`, which should catch any URLs  that are not source repositories. `guess_github` now matches on `git://github.com/` in addition to `git@github.com` (#247)
+* Changes in the way codeRepository is guessed. codemetar can now recognize an URL from GitHub, GitLab, Bitbucket, R-Forge among several URLs in DESCRIPTION, to assign it to codeRepository. If no URL in DESCRIPTION is from any of these providers, `guess_github()` is called.
 
 ## Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,27 @@
 # codemetar (development version)
 
+## Enhancements
+
+* codemetar can now recognize an URL from GitHub, GitLab, Bitbucket, R-Forge among several URLs in DESCRIPTION, to assign it to codeRepository. If there's only one URL in DESCRIPTION, it is assumed it is a codeRepository, no matter its domain.
+
+* Alter `create_codemeta` codeRepository assignment; force `guess_github` to be called if `cm$codeRepository` does not match a pattern of `https?://github.com`, which should catch any URLs  that are not source repositories. `guess_github` now matches on `git://github.com/` in addition to `git@github.com` (#247)
+
+## Bug fixes
+
+* Fix for detecting rOpenSci review badge (@sckott, #236)
+
+* Fix extraction of ORCID when composite comment (@billy34, #231)
+
+* Fix bug in crosswalking (#243)
+
+* Bug fix: the codeRepository is updated if there's any URL in DESCRIPTION.
+
 * Bug fix: the README information is now updated by codemeta_readme(). Previously if e.g. a developmentStatus had been set previously, it was never updated.
 
+## Internals
+
 * Code cleaning following the book Martin, Robert C. Clean code: a handbook of agile software craftsmanship. Pearson Education, 2009. (@hsonne, #201, #202, #204, #205, #206, #207, #209, #210, #211, #212, #216, #218, #219, #220, #221).
-* Fix for detecting rOpenSci review badge (@sckott, #236)
-* Fix extraction of orcid when composite comment (@billy34, #231)
-* Fix bug in crosswalking (#243)
-* Alter `create_codemeta` codeRepository assignment; force `guess_github` to be called if `cm$codeRepository` does not match a pattern of `https?://github.com`, which should catch any URLs  that are not source repositories. `guess_github` now matches on `git://github.com/` in addition to `git@github.com` (#247)
+
 
 # codemetar 0.1.8 2019-05
 

--- a/R/codemeta_description.R
+++ b/R/codemeta_description.R
@@ -265,7 +265,7 @@ add_additional_terms <- function(codemeta, descr) {
   codemeta
 }
 
-source_code_domains() <- function(){
+source_code_domains <- function(){
   c("github.com", "www.github.com",
     "gitlab.com",
     "r-forge.r-project.org",

--- a/R/codemeta_description.R
+++ b/R/codemeta_description.R
@@ -138,13 +138,8 @@ add_repository_terms <- function(codemeta, descr) {
     } else {
 
       # try to identify a code repo
-      url_info <- urltools::url_parse(code_repo)
-
-      actual_code_repo <- code_repo[url_info$domain %in%
-                                      c("github.com", "www.github.com",
-                                        "gitlab.com",
-                                        "r-forge.r-project.org",
-                                        "bitbucket.org")][1]
+      actual_code_repo <- code_repo[urltools::domain(code_repo) %in%
+                                      source_code_domains()][1]
 
       # otherwise take the first URL arbitrarily
       if (is.na(actual_code_repo)) {
@@ -270,3 +265,9 @@ add_additional_terms <- function(codemeta, descr) {
   codemeta
 }
 
+source_code_domains() <- function(){
+  c("github.com", "www.github.com",
+    "gitlab.com",
+    "r-forge.r-project.org",
+    "bitbucket.org")
+}

--- a/R/codemeta_description.R
+++ b/R/codemeta_description.R
@@ -146,7 +146,7 @@ add_repository_terms <- function(codemeta, descr) {
         codemeta$codeRepository <- code_repo[1]
       } else {
         # no direct link to README please
-        actual_code_repo <- gsub("#.*", "", actual_code_repo)
+        urltools::fragment(actual_code_repo) <- NULL
 
         codemeta$codeRepository <- actual_code_repo
 

--- a/R/codemeta_description.R
+++ b/R/codemeta_description.R
@@ -145,7 +145,7 @@ add_repository_terms <- function(codemeta, descr) {
       actual_code_repo <- gsub("#.*", "", actual_code_repo)
 
       # otherwise take the first URL arbitrarily
-      if (is.null(codemeta$Repository)) {
+      if (is.null(codemeta$codeRepository)) {
         codemeta$codeRepository <- actual_code_repo
       }
 

--- a/R/codemeta_description.R
+++ b/R/codemeta_description.R
@@ -137,16 +137,24 @@ add_repository_terms <- function(codemeta, descr) {
 
     } else {
 
-      # try to identify a GitHub or Gitlab repo
-      github_pattern <- "git(hub|lab)\\.com"
-      actual_code_repo <- grep(github_pattern, code_repo, value = TRUE)[1]
+      # try to identify a code repo
+      url_info <- urltools::url_parse(code_repo)
 
-      # no direct link to README please
-      actual_code_repo <- gsub("#.*", "", actual_code_repo)
+      actual_code_repo <- code_repo[url_info$domain %in%
+                                      c("github.com", "www.github.com",
+                                        "gitlab.com",
+                                        "r-forge.r-project.org",
+                                        "bitbucket.org")][1]
 
       # otherwise take the first URL arbitrarily
-      if (is.null(codemeta$codeRepository)) {
+      if (is.na(actual_code_repo)) {
+        codemeta$codeRepository <- code_repo[1]
+      } else {
+        # no direct link to README please
+        actual_code_repo <- gsub("#.*", "", actual_code_repo)
+
         codemeta$codeRepository <- actual_code_repo
+
       }
 
       # add other URLs as related links

--- a/R/codemeta_description.R
+++ b/R/codemeta_description.R
@@ -265,8 +265,12 @@ add_additional_terms <- function(codemeta, descr) {
   codemeta
 }
 
-source_code_domains <- function(){
-  c("github.com", "www.github.com",
+github_domains <- function() {
+  c("github.com", "www.github.com")
+}
+
+source_code_domains <- function() {
+  c(github_domains(),
     "gitlab.com",
     "r-forge.r-project.org",
     "bitbucket.org")

--- a/R/codemeta_readme.R
+++ b/R/codemeta_readme.R
@@ -71,7 +71,7 @@ guess_ropensci_review <- function(readme) {
   }
 
   url_m <- which_url_matches_badge_link(readme, c(url, url2))
-  review <- as.numeric(stringr::str_remove(badges, paste0(".*https://", url_m)))
+  review <- as.numeric(gsub(paste0(".*https://", url_m), "", badges))
 
   if (review %in% ropensci_reviews()$review) {
 

--- a/R/codemeta_readme.R
+++ b/R/codemeta_readme.R
@@ -91,7 +91,13 @@ guess_readme_url <- function(root) {
     return(NULL)
   }
 
-  github <- remotes::parse_github_url(guess_github(root))
+  github_url <- guess_github(root)
+
+  if (is.null(github_url)) {
+    return(NULL)
+  }
+
+  github <- remotes::parse_github_url(github_url)
 
   readme <- try(silent = TRUE, gh::gh(
     "GET /repos/:owner/:repo/readme",

--- a/R/codemeta_readme.R
+++ b/R/codemeta_readme.R
@@ -91,12 +91,12 @@ guess_readme_url <- function(root) {
     return(NULL)
   }
 
-  github <- stringr::str_remove(guess_github(root), ".*com\\/")
-
-  parts <- strsplit(github, "/")[[1]]
+  github <- remotes::parse_github_url(guess_github(root))
 
   readme <- try(silent = TRUE, gh::gh(
-    "GET /repos/:owner/:repo/readme", owner = parts[1], repo = parts[2]
+    "GET /repos/:owner/:repo/readme",
+    owner = github$username,
+    repo = github$repo
   ))
 
   if (! inherits(readme, "try-error")) {

--- a/R/create_codemeta.R
+++ b/R/create_codemeta.R
@@ -116,7 +116,8 @@ create_codemeta <- function(
   }
 
   ## If code repo is GitHub
-  if (grepl("github.com\\/.*\\/.*", cm$codeRepository)) {
+  if (urltools::domain(cm$codeRepository) %>%
+      github_domains()) {
 
     cm <- add_github_topics(cm)
   }

--- a/R/create_codemeta.R
+++ b/R/create_codemeta.R
@@ -15,19 +15,17 @@
 #' }
 #' @importFrom jsonlite read_json
 create_codemeta <- function(
-  pkg = ".",
-  root = ".",
-  id = NULL,
-  use_filesize = TRUE,
-  force_update =
-    getOption("codemeta_force_update", TRUE),
-  verbose = TRUE,
-  ...
-) {
+                            pkg = ".",
+                            root = ".",
+                            id = NULL,
+                            use_filesize = TRUE,
+                            force_update =
+                              getOption("codemeta_force_update", TRUE),
+                            verbose = TRUE,
+                            ...) {
 
   ## looks like we got a package name/path or Description file
   if (is.character(pkg)) {
-
     root <- get_root_path(pkg)
 
     # Set string constants
@@ -41,13 +39,11 @@ create_codemeta <- function(
 
       ## no cm, no existing codemeta.json found, start fresh
     } else {
-
       new_codemeta()
     }
 
     ## we got an existing codemeta object as pkg
   } else if (is.list(pkg)) {
-
     cm <- pkg
 
     ## root should be set already, we might check that root has a DESCRIPTION,
@@ -56,12 +52,10 @@ create_codemeta <- function(
   }
 
   if (verbose) {
-
     root <- get_root_path(pkg)
     opinions <- give_opinions(root)
 
-    if (! is.null(opinions)) {
-
+    if (!is.null(opinions)) {
       message(
         "Some elements could be improved, see our opinions via give_opinions('",
         root, "')"
@@ -75,27 +69,25 @@ create_codemeta <- function(
   ## Guess these only if not set in current codemeta
   # try to identify a code repo
 
-  if (! urltools::domain(cm$codeRepository) %in% source_code_domains()){
-    if (!is.null(guess_github(root)) && force_update) {
-      cm$relatedLink <- cm$codeRepository
-      cm$codeRepository <- guess_github(root)
+  if (!urltools::domain(cm$codeRepository) %in% source_code_domains()) {
+    if (uses_git(root)) {
+      if (!is.null(guess_github(root)) && force_update) {
+        cm$relatedLink <- cm$codeRepository
+        cm$codeRepository <- guess_github(root)
+      }
     }
   }
 
   if ((is.null(cm$releaseNotes) || force_update)) {
-
     cm$releaseNotes <- guess_releaseNotes(root)
   }
 
   if ((is.null(cm$readme) || force_update)) {
-
     cm$readme <- guess_readme(root)$readme_url
   }
 
   if (use_filesize) {
-
     if ((is.null(cm$fileSize) || force_update)) {
-
       cm$fileSize <- guess_fileSize(root)
     }
   }
@@ -103,20 +95,18 @@ create_codemeta <- function(
   # and if there's a readme
   readme <- guess_readme(root)$readme_path
 
-  if (! is.null(readme) && force_update) {
-
+  if (!is.null(readme) && force_update) {
     cm <- codemeta_readme(readme, codemeta = cm)
   }
 
   ## If code repo is GitHub
   if (urltools::domain(cm$codeRepository) %>%
-      github_domains()) {
-
+    github_domains()) {
     cm <- add_github_topics(cm)
   }
 
   ## Citation metadata
-  if (is.character(pkg)) {  ## Doesn't apply if pkg is a list (codemeta object)
+  if (is.character(pkg)) { ## Doesn't apply if pkg is a list (codemeta object)
 
     cm$citation <- guess_citation(pkg)
 
@@ -125,8 +115,7 @@ create_codemeta <- function(
 
     ## citations need schema.org context!
     ## see https://github.com/codemeta/codemeta/issues/155
-    if (! any(grepl(url_schema, cm$`@context`))) {
-
+    if (!any(grepl(url_schema, cm$`@context`))) {
       cm$`@context` <- c(cm$`@context`, url_schema)
     }
   }
@@ -137,27 +126,22 @@ create_codemeta <- function(
 
   provider <- guess_provider(cm$identifier)
 
-  if (! is.null(provider)) {
-
+  if (!is.null(provider)) {
     readme <- guess_readme(root)$readme_path
 
-    if (! is.null(readme)) {
-
+    if (!is.null(readme)) {
       badges <- extract_badges(readme)
 
-      if (! is.null(provider) &&
-          whether_provider_badge(badges, provider$name)) {
-
+      if (!is.null(provider) &&
+        whether_provider_badge(badges, provider$name)) {
         cm <- set_relatedLink_1(cm, provider)
       }
     } else if (cm$identifier %in% installed_package_names()) {
-
       pkg_info <- sessioninfo::package_info(cm$identifier)
       pkg_info <- pkg_info[pkg_info$package == cm$identifier, ]
       provider_name <- pkg_info$source
 
       if (cm$version == pkg_info$ondiskversion) {
-
         cm <- set_relatedLink_2(cm, provider_name)
       }
     }
@@ -169,15 +153,11 @@ create_codemeta <- function(
 
 # set_relatedLink_1 ------------------------------------------------------------
 set_relatedLink_1 <- function(codemeta, provider) {
-
   if (provider$name == "Comprehensive R Archive Network (CRAN)") {
-
     codemeta$relatedLink <- unique(c(
       codemeta$relatedLink, get_url_cran_package(codemeta$identifier)
     ))
-
   } else if (provider$name == "BioConductor") {
-
     codemeta$relatedLink <- unique(c(
       codemeta$relatedLink, get_url_bioconductor_package(codemeta$identifier)
     ))
@@ -188,24 +168,18 @@ set_relatedLink_1 <- function(codemeta, provider) {
 
 # set_relatedLink_2 ------------------------------------------------------------
 set_relatedLink_2 <- function(codemeta, provider_name) {
-
   if (grepl("CRAN", provider_name)) {
-
     codemeta$relatedLink <- unique(c(
       codemeta$relatedLink, get_url_cran_package(codemeta$identifier)
     ))
-
   } else if (grepl("Bioconductor", provider_name)) {
-
     codemeta$relatedLink <- unique(c(
       codemeta$relatedLink, get_url_bioconductor_package(codemeta$identifier)
     ))
-
   } else if (grepl("Github", provider_name)) {
 
     # if GitHub try to build the URL to commit or to repo in general
     if (grepl("@", provider_name)) {
-
       codemeta$relatedLink <- unique(c(
         codemeta$relatedLink, get_url_github_package(provider_name)
       ))

--- a/R/create_codemeta.R
+++ b/R/create_codemeta.R
@@ -73,11 +73,20 @@ create_codemeta <- function(
   cm <- codemeta_description(file.path(root, "DESCRIPTION"), id = id, cm)
 
   ## Guess these only if not set in current codemeta
+  # try to identify a code repo
+
+  if (! urltools::domain(cm$codeRepository) %in% source_code_domains()){
+    if (!is.null(guess_github(root)) && force_update) {
+      cm$relatedLink <- cm$codeRepository
+      cm$codeRepository <- guess_github(root)
+    }
+  }
+
   matches_gh <- grepl("https?://github.com.+", cm$codeRepository)
   if (length(matches_gh) == 0) matches_gh <- FALSE
   if ((is.null(cm$codeRepository) && force_update) || !matches_gh) {
 
-    cm$codeRepository <- guess_github(root)
+
   }
 
   if ((is.null(cm$releaseNotes) || force_update)) {

--- a/R/create_codemeta.R
+++ b/R/create_codemeta.R
@@ -100,7 +100,7 @@ create_codemeta <- function(
   }
 
   ## If code repo is GitHub
-  if (urltools::domain(cm$codeRepository) %>%
+  if (urltools::domain(cm$codeRepository) %in%
     github_domains()) {
     cm <- add_github_topics(cm)
   }

--- a/R/create_codemeta.R
+++ b/R/create_codemeta.R
@@ -82,13 +82,6 @@ create_codemeta <- function(
     }
   }
 
-  matches_gh <- grepl("https?://github.com.+", cm$codeRepository)
-  if (length(matches_gh) == 0) matches_gh <- FALSE
-  if ((is.null(cm$codeRepository) && force_update) || !matches_gh) {
-
-
-  }
-
   if ((is.null(cm$releaseNotes) || force_update)) {
 
     cm$releaseNotes <- guess_releaseNotes(root)

--- a/R/create_codemeta.R
+++ b/R/create_codemeta.R
@@ -70,12 +70,12 @@ create_codemeta <- function(
   # try to identify a code repo
 
   if (!urltools::domain(cm$codeRepository) %in% source_code_domains()) {
-    if (uses_git(root)) {
-      if (!is.null(guess_github(root)) && force_update) {
-        cm$relatedLink <- cm$codeRepository
-        cm$codeRepository <- guess_github(root)
-      }
+
+    if (!is.null(guess_github(root)) && force_update) {
+      cm$relatedLink <- cm$codeRepository
+      cm$codeRepository <- guess_github(root)
     }
+
   }
 
   if ((is.null(cm$releaseNotes) || force_update)) {

--- a/R/extract_badges.R
+++ b/R/extract_badges.R
@@ -50,8 +50,8 @@ extract_html_badges <- function(path) {
   # helper function assuming the badge table is the 1st one
   find_first <- function(p) which(grepl(p, doc))[1]
 
-  table_start <- find_first('\\<table class\\=\\"table\\"\\>')
-  table_end <- find_first('\\<\\/table\\>')
+  table_start <- find_first('\\<table class=\\"table\\">')
+  table_end <- find_first('<\\/table>')
 
   if (is.na(table_start) || is.na(table_end)) {
 

--- a/R/extract_badges.R
+++ b/R/extract_badges.R
@@ -48,7 +48,7 @@ extract_html_badges <- function(path) {
   doc <- readLines(path, encoding = "UTF-8")
 
   # helper function assuming the badge table is the 1st one
-  find_first <- function(p) which(stringr::str_detect(doc, p))[1]
+  find_first <- function(p) which(grepl(p, doc))[1]
 
   table_start <- find_first('\\<table class\\=\\"table\\"\\>')
   table_end <- find_first('\\<\\/table\\>')

--- a/R/guess_github_metadata.R
+++ b/R/guess_github_metadata.R
@@ -18,13 +18,21 @@ guess_github <- function(root = ".") {
     return(NULL)
   }
 
-  root %>%
+  potential_github_url <- root %>%
     git2r::repository(discover = TRUE) %>%
     remote_urls() %>%
     grep(pattern = "github", value = TRUE) %>%
-    getElement(1) %>%
-    gsub(pattern = "git@github.com:|git://github.com/", replacement = "https://github.com/") %>%
-    gsub(pattern = "\\.git$", replacement = "")
+    getElement(1)
+
+  github <- try(remotes::parse_github_url(potential_github_url),
+                silent = TRUE)
+
+  if (is(github, "try-error")) {
+    return(NULL)
+  } else {
+    return(github)
+  }
+
 }
 
 # github_path ------------------------------------------------------------------

--- a/R/guess_github_metadata.R
+++ b/R/guess_github_metadata.R
@@ -18,19 +18,26 @@ guess_github <- function(root = ".") {
     return(NULL)
   }
 
-  potential_github_url <- root %>%
+  remote_urls <- root %>%
     git2r::repository(discover = TRUE) %>%
-    remote_urls() %>%
-    grep(pattern = "github", value = TRUE) %>%
-    getElement(1)
+    remote_urls()
 
-  github <- try(remotes::parse_github_url(potential_github_url),
+  is_github <- function(url){
+    info <- try(remotes::parse_github_url(url),
                 silent = TRUE)
 
-  if (is(github, "try-error")) {
+    !is(info, "try-error")
+  }
+
+  whether_github <- unlist(
+    lapply(remote_urls, is_github))
+
+  github <- remote_urls[whether_github][1]
+
+  if (is.na(github)) {
     return(NULL)
   } else {
-    return(potential_github_url)
+    return(github)
   }
 
 }

--- a/R/guess_github_metadata.R
+++ b/R/guess_github_metadata.R
@@ -53,16 +53,12 @@ github_path <- function(root, path) {
 # add_github_topics ------------------------------------------------------------
 add_github_topics <- function(codemeta) {
 
-  github <- codemeta$codeRepository %>%
-    stringr::str_remove(".*github\\.com\\/") %>%
-    stringr::str_remove("#.*") %>%
-    stringr::str_split("/") %>%
-    getElement(1)
+  github <- remotes::parse_github_url(codemeta$codeRepository)
 
   topics <- try(silent = TRUE, gh::gh(
     endpoint = "GET /repos/:owner/:repo/topics",
-    repo = github[2],
-    owner = github[1],
+    repo = github$repo,
+    owner = github$username,
     .send_headers = c(Accept = "application/vnd.github.mercy-preview+json")
   ))
 

--- a/R/guess_github_metadata.R
+++ b/R/guess_github_metadata.R
@@ -30,7 +30,7 @@ guess_github <- function(root = ".") {
   if (is(github, "try-error")) {
     return(NULL)
   } else {
-    return(github)
+    return(potential_github_url)
   }
 
 }

--- a/R/parse_depends.R
+++ b/R/parse_depends.R
@@ -42,7 +42,7 @@ get_sameAs <- function(provider, remote_provider, identifier) {
   # The remote provider takes precedence over the non-remote provider
   if (remote_provider != "") {
 
-    get_url_github(stringr::str_remove(remote_provider, "github::"))
+    get_url_github(gsub("github::", "", remote_provider))
 
   } else if (! is.null(provider) && provider$name %in% names(url_generators)) {
 

--- a/inst/examples/DESCRIPTION_bitbucket
+++ b/inst/examples/DESCRIPTION_bitbucket
@@ -1,8 +1,8 @@
 Package: codemetar
 Type: Package
 Title: Generate 'CodeMeta' Metadata for R Packages
-Version: 0.1.8.9000
-Authors@R: 
+Version: 0.1.6
+Authors@R:
     c(person(given = "Carl",
              family = "Boettiger",
              role = c("aut", "cre", "cph"),
@@ -25,48 +25,30 @@ Authors@R:
              comment = "https://ropensci.org/"),
       person(given = "Katrin",
              family = "Leinweber",
-             role = "ctb",
-             comment = c(ORCID = "0000-0001-5135-5758")),
+             role = "ctb"),
       person(given = "Noam",
              family = "Ross",
-             role = "ctb",
-             comment = c(ORCID = "0000-0002-2136-0000")),
+             role = "ctb"),
       person(given = "Arfon",
              family = "Smith",
-             role = "ctb"),
-      person(given = "Jeroen",
-             family = "Ooms",
-             role = "ctb",
-             comment = c(ORCID = "0000-0002-4035-0289")),
-      person(given = "Sebastian",
-             family = "Meyer",
-             role = "ctb",
-             comment = c(ORCID = "0000-0002-1791-9449")),
-      person(given = "Michael",
-             family = "Rustler",
-             role = "ctb",
-             comment = c(ORCID = "0000-0003-0647-7726")),
-      person(given = "Hauke",
-             family = "Sonnenberg",
-             role = "ctb",
-             comment = c(ORCID = "0000-0001-9134-2871"))
-      )
+             role = "ctb"))
 Description: The 'Codemeta' Project defines a 'JSON-LD' format for describing
   software metadata, as detailed at <https://codemeta.github.io>. This package
-  provides utilities to generate, parse, and modify 'codemeta.json' files 
+  provides utilities to generate, parse, and modify 'codemeta.json' files
   automatically for R packages, as well as tools and examples for working with
   'codemeta.json' 'JSON-LD' more generally.
 License: GPL-3
-URL: https://github.com/ropensci/codemetar, https://docs.ropensci.org/codemetar
+URL: https://bitbucket.org/ropensci/codemetar, https://ropensci.github.io/codemetar
 BugReports: https://github.com/ropensci/codemetar/issues
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 6.1.1
+RoxygenNote: 6.0.1.9000
 Depends: R (>= 3.0.0)
-Imports: 
-    jsonlite (>= 1.6),
+Imports:
+    jsonlite (>= 1.3),
+    jsonld,
     git2r,
-    pkgbuild,
+    devtools,
     memoise,
     methods,
     stats,
@@ -80,21 +62,15 @@ Imports:
     gh,
     stringr,
     sessioninfo,
-    purrr,
-    curl,
-    commonmark,
-    xml2,
-    magrittr,
-    glue,
-    pingr,
-    urltools
-Suggests: 
-    testthat (>= 2.1.0),
-    jsonld,
+    purrr
+Suggests:
+    testthat,
     jsonvalidate,
     covr,
     knitr,
     rmarkdown,
+    magrittr,
+    xml2,
     dplyr (>= 0.7.0),
     printr
 VignetteBuilder: knitr

--- a/inst/examples/DESCRIPTION_gitlab
+++ b/inst/examples/DESCRIPTION_gitlab
@@ -1,8 +1,8 @@
 Package: codemetar
 Type: Package
 Title: Generate 'CodeMeta' Metadata for R Packages
-Version: 0.1.8.9000
-Authors@R: 
+Version: 0.1.6
+Authors@R:
     c(person(given = "Carl",
              family = "Boettiger",
              role = c("aut", "cre", "cph"),
@@ -25,48 +25,30 @@ Authors@R:
              comment = "https://ropensci.org/"),
       person(given = "Katrin",
              family = "Leinweber",
-             role = "ctb",
-             comment = c(ORCID = "0000-0001-5135-5758")),
+             role = "ctb"),
       person(given = "Noam",
              family = "Ross",
-             role = "ctb",
-             comment = c(ORCID = "0000-0002-2136-0000")),
+             role = "ctb"),
       person(given = "Arfon",
              family = "Smith",
-             role = "ctb"),
-      person(given = "Jeroen",
-             family = "Ooms",
-             role = "ctb",
-             comment = c(ORCID = "0000-0002-4035-0289")),
-      person(given = "Sebastian",
-             family = "Meyer",
-             role = "ctb",
-             comment = c(ORCID = "0000-0002-1791-9449")),
-      person(given = "Michael",
-             family = "Rustler",
-             role = "ctb",
-             comment = c(ORCID = "0000-0003-0647-7726")),
-      person(given = "Hauke",
-             family = "Sonnenberg",
-             role = "ctb",
-             comment = c(ORCID = "0000-0001-9134-2871"))
-      )
+             role = "ctb"))
 Description: The 'Codemeta' Project defines a 'JSON-LD' format for describing
   software metadata, as detailed at <https://codemeta.github.io>. This package
-  provides utilities to generate, parse, and modify 'codemeta.json' files 
+  provides utilities to generate, parse, and modify 'codemeta.json' files
   automatically for R packages, as well as tools and examples for working with
   'codemeta.json' 'JSON-LD' more generally.
 License: GPL-3
-URL: https://github.com/ropensci/codemetar, https://docs.ropensci.org/codemetar
+URL: https://gitlab.com/ropensci/codemetar, https://ropensci.github.io/codemetar
 BugReports: https://github.com/ropensci/codemetar/issues
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 6.1.1
+RoxygenNote: 6.0.1.9000
 Depends: R (>= 3.0.0)
-Imports: 
-    jsonlite (>= 1.6),
+Imports:
+    jsonlite (>= 1.3),
+    jsonld,
     git2r,
-    pkgbuild,
+    devtools,
     memoise,
     methods,
     stats,
@@ -80,21 +62,15 @@ Imports:
     gh,
     stringr,
     sessioninfo,
-    purrr,
-    curl,
-    commonmark,
-    xml2,
-    magrittr,
-    glue,
-    pingr,
-    urltools
-Suggests: 
-    testthat (>= 2.1.0),
-    jsonld,
+    purrr
+Suggests:
+    testthat,
     jsonvalidate,
     covr,
     knitr,
     rmarkdown,
+    magrittr,
+    xml2,
     dplyr (>= 0.7.0),
     printr
 VignetteBuilder: knitr

--- a/man/codemetar-package.Rd
+++ b/man/codemetar-package.Rd
@@ -45,25 +45,25 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Carl Boettiger \email{cboettig@gmail.com} (0000-0002-1642-628X) [copyright holder]
+\strong{Maintainer}: Carl Boettiger \email{cboettig@gmail.com} (\href{https://orcid.org/0000-0002-1642-628X}{ORCID}) [copyright holder]
 
 Authors:
 \itemize{
-  \item Maëlle Salmon (0000-0002-2815-0399) [contributor]
+  \item Maëlle Salmon (\href{https://orcid.org/0000-0002-2815-0399}{ORCID}) [contributor]
 }
 
 Other contributors:
 \itemize{
-  \item Anna Krystalli (0000-0002-2378-4915) [reviewer, contributor]
-  \item Toph Allen (0000-0003-4580-091X) [reviewer]
+  \item Anna Krystalli (\href{https://orcid.org/0000-0002-2378-4915}{ORCID}) [reviewer, contributor]
+  \item Toph Allen (\href{https://orcid.org/0000-0003-4580-091X}{ORCID}) [reviewer]
   \item rOpenSci (https://ropensci.org/) [funder]
-  \item Katrin Leinweber (0000-0001-5135-5758) [contributor]
-  \item Noam Ross (0000-0002-2136-0000) [contributor]
+  \item Katrin Leinweber (\href{https://orcid.org/0000-0001-5135-5758}{ORCID}) [contributor]
+  \item Noam Ross (\href{https://orcid.org/0000-0002-2136-0000}{ORCID}) [contributor]
   \item Arfon Smith [contributor]
-  \item Jeroen Ooms (0000-0002-4035-0289) [contributor]
-  \item Sebastian Meyer (0000-0002-1791-9449) [contributor]
-  \item Michael Rustler (0000-0003-0647-7726) [contributor]
-  \item Hauke Sonnenberg (0000-0001-9134-2871) [contributor]
+  \item Jeroen Ooms (\href{https://orcid.org/0000-0002-4035-0289}{ORCID}) [contributor]
+  \item Sebastian Meyer (\href{https://orcid.org/0000-0002-1791-9449}{ORCID}) [contributor]
+  \item Michael Rustler (\href{https://orcid.org/0000-0003-0647-7726}{ORCID}) [contributor]
+  \item Hauke Sonnenberg (\href{https://orcid.org/0000-0001-9134-2871}{ORCID}) [contributor]
 }
 
 }

--- a/man/create_codemeta.Rd
+++ b/man/create_codemeta.Rd
@@ -4,10 +4,15 @@
 \alias{create_codemeta}
 \title{create_codemeta}
 \usage{
-create_codemeta(pkg = ".", root = ".", id = NULL,
+create_codemeta(
+  pkg = ".",
+  root = ".",
+  id = NULL,
   use_filesize = TRUE,
   force_update = getOption("codemeta_force_update", TRUE),
-  verbose = TRUE, ...)
+  verbose = TRUE,
+  ...
+)
 }
 \arguments{
 \item{pkg}{package path to package root, or package name, or description file

--- a/man/write_codemeta.Rd
+++ b/man/write_codemeta.Rd
@@ -4,10 +4,17 @@
 \alias{write_codemeta}
 \title{write_codemeta}
 \usage{
-write_codemeta(pkg = ".", path = "codemeta.json", root = ".",
-  id = NULL, use_filesize = TRUE,
+write_codemeta(
+  pkg = ".",
+  path = "codemeta.json",
+  root = ".",
+  id = NULL,
+  use_filesize = TRUE,
   force_update = getOption("codemeta_force_update", TRUE),
-  use_git_hook = TRUE, verbose = TRUE, ...)
+  use_git_hook = TRUE,
+  verbose = TRUE,
+  ...
+)
 }
 \arguments{
 \item{pkg}{package path to package root, or package name, or description file

--- a/tests/testthat/test-add_repository_terms.R
+++ b/tests/testthat/test-add_repository_terms.R
@@ -47,3 +47,17 @@ testthat::test_that("no direct link to README", {
   expect_true("https://github.com/ropensci/codemetar#codemetar" %in%
                 cm$relatedLink)
 })
+
+testthat::test_that("update URL", {
+
+  cm <- new_codemeta()
+  cm$codeRepository <- "lalala"
+
+  cm <- add_repository_terms(cm,
+                             desc::desc(
+                               example_file(
+                                 "DESCRIPTION_two_URLs")))
+  expect_equal(cm$codeRepository, "https://github.com/ropensci/essurvey")
+  expect_true("https://ropensci.github.io/essurvey/" %in%
+                cm$relatedLink)
+})

--- a/tests/testthat/test-add_repository_terms.R
+++ b/tests/testthat/test-add_repository_terms.R
@@ -1,0 +1,49 @@
+test_that("add_repository_terms works", {
+  # Provide testdata
+  codemeta <- new_codemeta()
+  codemeta$package <- "abc"
+  descr <- desc::desc(example_file("DESCRIPTION_good"))
+
+  expect_error(add_repository_terms())
+  result <- add_repository_terms(codemeta, descr = descr)
+  expect_true(all(c("codeRepository", "relatedLink") %in% names(result)))
+
+})
+
+testthat::test_that("several URLs", {
+
+  cm <- add_repository_terms(new_codemeta(),
+                             desc::desc(
+                               example_file(
+                                 "DESCRIPTION_two_URLs")))
+  expect_equal(cm$codeRepository, "https://github.com/ropensci/essurvey")
+  expect_true("https://ropensci.github.io/essurvey/" %in%
+                cm$relatedLink)
+})
+
+testthat::test_that("not GitHub", {
+  cm <- add_repository_terms(codemeta = new_codemeta(),
+                             descr = desc::desc(
+                               example_file(
+                                 "DESCRIPTION_gitlab")))
+  expect_equal(cm$codeRepository, "https://gitlab.com/ropensci/codemetar")
+  expect_true("https://ropensci.github.io/codemetar" %in%
+                cm$relatedLink)
+
+  cm <- add_repository_terms(codemeta = new_codemeta(),
+                             descr = desc::desc(
+                               example_file(
+                                 "DESCRIPTION_bitbucket")))
+  expect_equal(cm$codeRepository, "https://bitbucket.org/ropensci/codemetar")
+  expect_true("https://ropensci.github.io/codemetar" %in%
+                cm$relatedLink)
+})
+
+testthat::test_that("no direct link to README", {
+  cm <- codemeta_description(example_file("DESCRIPTION_good_readmeinurl"))
+  expect_equal(cm$codeRepository, "https://github.com/ropensci/codemetar")
+  expect_true("https://ropensci.github.io/codemetar" %in%
+                cm$relatedLink)
+  expect_true("https://github.com/ropensci/codemetar#codemetar" %in%
+                cm$relatedLink)
+})

--- a/tests/testthat/test-codemeta_description.R
+++ b/tests/testthat/test-codemeta_description.R
@@ -7,24 +7,6 @@ testthat::test_that("We can use a preset id", {
   codemeta_description(f, id = "https://doi.org/10.looks.like/doi")
 })
 
-testthat::test_that("several URLs", {
-  skip_if_offline()
-  skip_on_cran()
-  cm <- codemeta_description(example_file("DESCRIPTION_two_URLs"))
-  expect_equal(cm$codeRepository, "https://github.com/ropensci/essurvey")
-  expect_true("https://ropensci.github.io/essurvey/" %in%
-                cm$relatedLink)
-})
-
-testthat::test_that("no direct link to README", {
-  cm <- codemeta_description(example_file("DESCRIPTION_good_readmeinurl"))
-  expect_equal(cm$codeRepository, "https://github.com/ropensci/codemetar")
-  expect_true("https://ropensci.github.io/codemetar" %in%
-                cm$relatedLink)
-  expect_true("https://github.com/ropensci/codemetar#codemetar" %in%
-                cm$relatedLink)
-})
-
 testthat::test_that("We can parse additional terms", {
   cm <- codemeta_description(example_file("DESCRIPTION_ex1.dcf"))
   testthat::expect_equal(length(cm$keywords), 6)
@@ -56,11 +38,6 @@ testthat::test_that("Helper functions work correctly", {
   codemeta <- new_codemeta()
   codemeta$package <- "abc"
   descr <- desc::desc(example_file("DESCRIPTION_good"))
-
-  # test add_repository_terms()
-  expect_error(add_repository_terms())
-  result <- add_repository_terms(codemeta, descr)
-  expect_true(all(c("codeRepository", "relatedLink") %in% names(result)))
 
   # test add_language_terms()
   expect_error(add_language_terms())


### PR DESCRIPTION
Summary

* Should fix #245 (at least it does for me, I cloned one of the repos and was able to create_codemeta()).
* Adds two dependencies to parse URLs (urltools, and remotes) so that we don't need to write the regular expressions.
* Slightly change what @sckott had changed but I think it's fine (if the codeRepository is not a source repo, we try to guess the GitHub root).
* Removes the stringr dependency but not the stringi dependency yet.


Code repos domain identified via https://github.com/r-hub/blog/issues/39#issue-a525837195