### PR TITLE
add dot_to_package fn like rprojroot

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,7 +29,7 @@ jobs:
           - {os: ubuntu-16.04,   r: '3.3',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
 
     env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      R_REMOTES_NO_ERRORS_FROM_WARNINGS: false
       RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -86,6 +86,7 @@ Imports:
     xml2,
     cli
 Suggests: 
+    withr,
     covr,
     details,
     dplyr (>= 0.7.0),

--- a/R/utils.R
+++ b/R/utils.R
@@ -138,6 +138,36 @@ whether_provider_badge <- function(badges, provider_name) {
   )
 }
 
+# dot_to_package: convert pkg = "." to proper package path ------------------
+dot_to_package <- function(pkg = ".") {
+
+    # https://github.com/r-lib/rprojroot/blob/master/R/root.R#L115:
+    .max_depth <- 10L
+
+    files <- c("DESCRIPTION", "NAMESPACE", "man", "R")
+
+    if (pkg == "." | !all(files %in% list.files(pkg))) {
+
+        pkg <- normalizePath(pkg)
+
+        if (!all(files %in% list.files(pkg))) {
+
+            for (i in seq_len(.max_depth)) {
+
+                pkg <- normalizePath(file.path(pkg, ".."))
+
+                if (all(files %in% list.files(pkg)))
+                    return(pkg)
+            }
+        }
+    }
+
+    if (!all(files %in% list.files(pkg)))
+        stop("Unable to find root directory of an R package")
+
+    return(pkg)
+}
+
 # is_package: helper to find whether a path is a package project ---------------
 is_package <- function(path) {
 

--- a/R/write_codemeta.R
+++ b/R/write_codemeta.R
@@ -58,8 +58,10 @@ write_codemeta <- function(
   codemeta_json <- "codemeta.json"
 
   # Things that only happen inside a package folder...
-  if (pkg == ".")
-      pkg <- dot_to_package(pkg)
+  if (pkg == ".") {
+    pkg <- dot_to_package(pkg)
+  }
+
   in_package <- length(pkg) <= 1 && is_package(pkg) && pkg %in% c(getwd(), ".")
 
   # ... and when the output file is codemeta.json. If path is something else

--- a/R/write_codemeta.R
+++ b/R/write_codemeta.R
@@ -58,6 +58,8 @@ write_codemeta <- function(
   codemeta_json <- "codemeta.json"
 
   # Things that only happen inside a package folder...
+  if (pkg == ".")
+      pkg <- dot_to_package(pkg)
   in_package <- length(pkg) <= 1 && is_package(pkg) && pkg %in% c(getwd(), ".")
 
   # ... and when the output file is codemeta.json. If path is something else

--- a/codemeta.json
+++ b/codemeta.json
@@ -1,0 +1,459 @@
+{
+  "@context": ["https://doi.org/10.5063/schema/codemeta-2.0", "http://schema.org"],
+  "@type": "SoftwareSourceCode",
+  "identifier": "codemetar",
+  "description": "The 'Codemeta' Project defines a 'JSON-LD' format\n    for describing software metadata, as detailed at\n    <https://codemeta.github.io>. This package provides utilities to\n    generate, parse, and modify 'codemeta.json' files automatically for R\n    packages, as well as tools and examples for working with\n    'codemeta.json' 'JSON-LD' more generally.",
+  "name": "codemetar: Generate 'CodeMeta' Metadata for R Packages",
+  "codeRepository": "https://github.com/ropensci/codemetar",
+  "relatedLink": ["https://docs.ropensci.org/codemetar", "https://CRAN.R-project.org/package=codemetar"],
+  "issueTracker": "https://github.com/ropensci/codemetar/issues",
+  "license": "https://spdx.org/licenses/GPL-3.0",
+  "version": "0.1.9",
+  "programmingLanguage": {
+    "@type": "ComputerLanguage",
+    "name": "R",
+    "url": "https://r-project.org"
+  },
+  "runtimePlatform": "R version 4.0.2 (2020-06-22)",
+  "provider": {
+    "@id": "https://cran.r-project.org",
+    "@type": "Organization",
+    "name": "Comprehensive R Archive Network (CRAN)",
+    "url": "https://cran.r-project.org"
+  },
+  "author": [
+    {
+      "@type": "Person",
+      "givenName": "Carl",
+      "familyName": "Boettiger",
+      "email": "cboettig@gmail.com",
+      "@id": "https://orcid.org/0000-0002-1642-628X"
+    },
+    {
+      "@type": "Person",
+      "givenName": "Maëlle",
+      "familyName": "Salmon",
+      "@id": "https://orcid.org/0000-0002-2815-0399"
+    }
+  ],
+  "contributor": [
+    {
+      "@type": "Person",
+      "givenName": "Anna",
+      "familyName": "Krystalli",
+      "@id": "https://orcid.org/0000-0002-2378-4915"
+    },
+    {
+      "@type": "Person",
+      "givenName": "Maëlle",
+      "familyName": "Salmon",
+      "@id": "https://orcid.org/0000-0002-2815-0399"
+    },
+    {
+      "@type": "Person",
+      "givenName": "Katrin",
+      "familyName": "Leinweber",
+      "@id": "https://orcid.org/0000-0001-5135-5758"
+    },
+    {
+      "@type": "Person",
+      "givenName": "Noam",
+      "familyName": "Ross",
+      "@id": "https://orcid.org/0000-0002-2136-0000"
+    },
+    {
+      "@type": "Person",
+      "givenName": "Arfon",
+      "familyName": "Smith"
+    },
+    {
+      "@type": "Person",
+      "givenName": "Jeroen",
+      "familyName": "Ooms",
+      "@id": "https://orcid.org/0000-0002-4035-0289"
+    },
+    {
+      "@type": "Person",
+      "givenName": "Sebastian",
+      "familyName": "Meyer",
+      "@id": "https://orcid.org/0000-0002-1791-9449"
+    },
+    {
+      "@type": "Person",
+      "givenName": "Michael",
+      "familyName": "Rustler",
+      "@id": "https://orcid.org/0000-0003-0647-7726"
+    },
+    {
+      "@type": "Person",
+      "givenName": "Hauke",
+      "familyName": "Sonnenberg",
+      "@id": "https://orcid.org/0000-0001-9134-2871"
+    },
+    {
+      "@type": "Person",
+      "givenName": "Sebastian",
+      "familyName": "Kreutzer",
+      "@id": "https://orcid.org/0000-0002-0734-2199"
+    }
+  ],
+  "copyrightHolder": [
+    {
+      "@type": "Person",
+      "givenName": "Carl",
+      "familyName": "Boettiger",
+      "email": "cboettig@gmail.com",
+      "@id": "https://orcid.org/0000-0002-1642-628X"
+    }
+  ],
+  "funder": [
+    {
+      "@type": "Organization",
+      "name": "rOpenSci"
+    }
+  ],
+  "maintainer": [
+    {
+      "@type": "Person",
+      "givenName": "Carl",
+      "familyName": "Boettiger",
+      "email": "cboettig@gmail.com",
+      "@id": "https://orcid.org/0000-0002-1642-628X"
+    }
+  ],
+  "softwareSuggestions": [
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "covr",
+      "name": "covr",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=covr"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "details",
+      "name": "details",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=details"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "dplyr",
+      "name": "dplyr",
+      "version": ">= 0.7.0",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=dplyr"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "jsonld",
+      "name": "jsonld",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=jsonld"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "jsonvalidate",
+      "name": "jsonvalidate",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=jsonvalidate"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "knitr",
+      "name": "knitr",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=knitr"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "printr",
+      "name": "printr",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=printr"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "rmarkdown",
+      "name": "rmarkdown",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=rmarkdown"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "testthat",
+      "name": "testthat",
+      "version": ">= 2.1.0",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=testthat"
+    }
+  ],
+  "softwareRequirements": [
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "R",
+      "name": "R",
+      "version": ">= 3.2.0"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "commonmark",
+      "name": "commonmark",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=commonmark"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "crul",
+      "name": "crul",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=crul"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "desc",
+      "name": "desc",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=desc"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "gert",
+      "name": "gert",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=gert"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "gh",
+      "name": "gh",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=gh"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "jsonlite",
+      "name": "jsonlite",
+      "version": ">= 1.6",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=jsonlite"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "magrittr",
+      "name": "magrittr",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=magrittr"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "memoise",
+      "name": "memoise",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=memoise"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "methods",
+      "name": "methods"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "pingr",
+      "name": "pingr",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=pingr"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "pkgbuild",
+      "name": "pkgbuild",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=pkgbuild"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "purrr",
+      "name": "purrr",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=purrr"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "remotes",
+      "name": "remotes",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=remotes"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "sessioninfo",
+      "name": "sessioninfo",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=sessioninfo"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "stats",
+      "name": "stats"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "urltools",
+      "name": "urltools",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=urltools"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "xml2",
+      "name": "xml2",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=xml2"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "cli",
+      "name": "cli",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=cli"
+    }
+  ],
+  "isPartOf": "https://ropensci.org",
+  "keywords": ["metadata", "codemeta", "ropensci", "citation", "credit", "linked-data", "json-ld", "r", "rstats", "r-package", "peer-reviewed"],
+  "releaseNotes": "https://github.com/ropensci/codemetar/blob/master/NEWS.md",
+  "readme": "https://github.com/ropensci/codemetar/blob/master/README.md",
+  "fileSize": "1466.238KB",
+  "contIntegration": ["https://travis-ci.org/ropensci/codemetar", "https://ci.appveyor.com/project/cboettig/codemetar/branch/master", "https://codecov.io/github/ropensci/codemetar?branch=master"],
+  "developmentStatus": "http://www.repostatus.org/#active",
+  "review": {
+    "@type": "Review",
+    "url": "https://github.com/ropensci/software-review/issues/130",
+    "provider": "https://ropensci.org"
+  }
+}

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -29,3 +29,11 @@ testthat::test_that("example_file works", {
 
 })
 
+testthat::test_that("dot_to_package", {
+  p0 <- get_root_path("jsonld")
+  p <- file.path(p0, "R")
+  wd <- setwd(p)
+  testthat::expect_error(dot_to_package("."),
+                         "Unable to find root directory")
+  setwd(wd)
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -30,10 +30,8 @@ testthat::test_that("example_file works", {
 })
 
 testthat::test_that("dot_to_package", {
-  p0 <- get_root_path("jsonld")
-  p <- file.path(p0, "R")
-  wd <- setwd(p)
+  p0 <- get_root_path("desc")
+  withr::local_dir(new = file.path(p0, "R"))
   testthat::expect_error(dot_to_package("."),
                          "Unable to find root directory")
-  setwd(wd)
 })


### PR DESCRIPTION
This enables `write_codemetar` to be called from anywhere within a package directory structure. It is essentially a hard-coded version of what `rprojroot` does to locate the root of an R package. Pretty sure it has no effects on anything else, as it's only evoked when `pkg = "."`.

``` r
library(codemetar) # current version prior to this PR
setwd (<path>/<to>/<local>/<codemetar>)
setwd("./R")

write_codemeta()
#> Error: File `./DESCRIPTION' does not exist
```
That's annoying because it does exist! With this PR:
``` r
devtools::load_all (".", export_all = FALSE) # Version with this PR
#> Loading codemetar
write_codemeta()
#> … Getting CRAN metadata from RStudio CRAN mirror
#> ✔ Got CRAN metadata!
#> codemetar has the highest opinion of this R package :-)
#> … Getting Bioconductor metadata
#> ✔ Got Bioconductor metadata!
#> … Getting sysreqs URL from sysreqs API
#> ✔ Got sysreqs URL from sysreqs API!
#> … Asking README URL from GitHub API
#> ✔ Got README URL!
#> … Asking README URL from GitHub API
#> ✔ Got README URL!
#> … Getting repo topics from GitHub API
#> ✔ Got repo topics!
```

<sup>Created on 2021-02-16 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>

That's better!