### PR TITLE
omit Translating using JSON-LD article

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -32,8 +32,6 @@ navbar:
       menu:
       - text: Parsing Codemeta Data
         href: articles/articles/examples-parsing-codemeta.html
-      - text: Translating between schema using JSON-LD
-        href: articles/articles/translating-codemeta.html
       - text: Validation in JSON-LD
         href: articles/articles/validation-in-json-ld.html
     news:


### PR DESCRIPTION
IIUC from #288, #291 and 3fa69d81332a0e591336a4b9084144a44a75d7da this article is not relevant anymore with `crosswalk()` deprecated. 
In any case, the [link to the article](https://docs.ropensci.org/codemetar/articles/articles/translating-codemeta.html) leads to a 404 error. 