### PR TITLE
Remove link to `dev` branch, use devtools

### DIFF
--- a/man/rmdhunks/install-instructions.Rmd
+++ b/man/rmdhunks/install-instructions.Rmd
@@ -7,6 +7,6 @@ install.packages("codemetar")
 You can also install the development version of `codemetar` from GitHub with:
 
 ```{r gh-installation, eval = FALSE}
-# install.packages("remotes")
-remotes::install_github("ropensci/codemetar", ref = "dev")
+# install.packages("devtools")
+devtools::install_github("ropensci/codemetar")
 ```


### PR DESCRIPTION
The installation instructions for the development version mention the `dev` branch, which no longer exists. I assume the development version lives on the default (`master`) branch, and a `rev` attribute is not needed.

I also updated the instructions to the more commonly used `devtools` rather than `remotes` to install, but that is just an opinion, not a bugfix.