### PR TITLE
Update licenseId examples in codemeta_schema.json

### DIFF
--- a/inst/schema/codemeta_schema.json
+++ b/inst/schema/codemeta_schema.json
@@ -145,7 +145,7 @@
           "type":["array", "string"]
       },
       "licenseId": {
-          "description":"The name of the license agreement governing the use and redistribution of the software. e.g. 'Apache-2.0', 'GPL-3.0', 'LGPL-3.0'",
+          "description":"The name of the license agreement governing the use and redistribution of the software. e.g. 'Apache-2.0', 'GPL-3.0-only', 'LGPL-3.0-or-later'",
           "type":"string"
       },
       "title":{


### PR DESCRIPTION
In licenseId examples,
- replaced `GPL-3.0` and `LGPL-3.0`
- with `GPL-3.0-only` and `LGPL-3.0-or-later`

## Reason

`GPL-3.0` and `LGPL-3.0` are deprecated in SPDX license list:
- https://spdx.org/licenses/GPL-3.0
- https://spdx.org/licenses/LGPL-3.0

New license IDs are `GPL-3.0-only`,`GPL-3.0-or-later`, `LGPL-3.0-only` and `LGPL-3.0-or-later`:
- https://spdx.org/licenses/GPL-3.0-only
- https://spdx.org/licenses/GPL-3.0-or-later
- https://spdx.org/licenses/LGPL-3.0-only
- https://spdx.org/licenses/LGPL-3.0-or-later